### PR TITLE
refactor(standards): Phase 2 initial tasks - link cleanup and U-KEYRE…

### DIFF
--- a/master-knowledge-base/standards/src/AS-SCHEMA-CONCEPT-DEFINITION.md
+++ b/master-knowledge-base/standards/src/AS-SCHEMA-CONCEPT-DEFINITION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition" # Defines a standard for document structure
 primary-topic: "Schema for Concept Definitions"
-related-standards: ["AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-DOC-CHAPTER"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -33,7 +33,7 @@ This schema MUST be applied to all documents that primarily define a core concep
 
 ## 2. Mandatory Document Structure
 
-Documents following this schema MUST adhere to the general internal structure for "Chapters" as defined in [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]]. This includes:
+Documents following this schema MUST adhere to the general internal structure for "Chapters" as defined in [[AS-STRUCTURE-DOC-CHAPTER]]. This includes:
 
 ### Rule 2.1: H1 Title (Derived from U-SCHEMA-CONCEPT-001, Rule 1.2)
 The H1 title of the document MUST be the specific name of the concept or term being defined.
@@ -41,11 +41,11 @@ The H1 title of the document MUST be the specific name of the concept or term be
 
 ### Rule 2.2: Introductory Abstract (Derived from U-SCHEMA-CONCEPT-001, Rule 1.3)
 An introductory abstract that summarizes the concept's meaning and significance MUST be included immediately after the H1 title.
-*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] for details on abstract content.
+*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER]] for details on abstract content.
 
 ### Rule 2.3: Table of Contents (ToC) (Derived from U-SCHEMA-CONCEPT-001, Rule 1.4)
 A Table of Contents (ToC) MUST follow the abstract, linking to all H2 sections and significant H3 sections.
-*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] for ToC requirements.
+*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER]] for ToC requirements.
 
 ## 3. Required Sections (H2 Level) (Derived from U-SCHEMA-CONCEPT-001, Rule 1.5)
 
@@ -108,7 +108,7 @@ A new drug is tested against a placebo. Statistical significance helps determine
 ```
 
 ## 5. Cross-References
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - For general chapter structure requirements (H1, abstract, ToC, summary, see also).
+- [[AS-STRUCTURE-DOC-CHAPTER]] - For general chapter structure requirements (H1, abstract, ToC, summary, see also).
 
 ---
 *This standard (AS-SCHEMA-CONCEPT-DEFINITION) is based on rules 1.1 through 1.7 previously defined in U-SCHEMA-CONCEPT-001 from COL-CONTENT-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-SCHEMA-METHODOLOGY-DESCRIPTION.md
+++ b/master-knowledge-base/standards/src/AS-SCHEMA-METHODOLOGY-DESCRIPTION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition" # Defines a standard for document structure
 primary-topic: "Schema for Methodology/Technique Descriptions"
-related-standards: ["AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER", "CS-POLICY-LAYERED-INFORMATION_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-DOC-CHAPTER", "CS-POLICY-LAYERED-INFORMATION"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -34,7 +34,7 @@ This schema MUST be applied to all documents that describe a specific methodolog
 
 ## 2. Mandatory Document Structure
 
-Documents following this schema MUST adhere to the general internal structure for "Chapters" as defined in [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]]. This includes:
+Documents following this schema MUST adhere to the general internal structure for "Chapters" as defined in [[AS-STRUCTURE-DOC-CHAPTER]]. This includes:
 
 ### Rule 2.1: H1 Title (Derived from U-SCHEMA-METHOD-001, Rule 1.2)
 The H1 title of the document MUST be the specific name of the methodology or technique being described.
@@ -42,11 +42,11 @@ The H1 title of the document MUST be the specific name of the methodology or tec
 
 ### Rule 2.2: Introductory Abstract (Derived from U-SCHEMA-METHOD-001, Rule 1.3)
 An introductory abstract that summarizes the method, its purpose, and key outcomes MUST be included immediately after the H1 title.
-*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] for details on abstract content.
+*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER]] for details on abstract content.
 
 ### Rule 2.3: Table of Contents (ToC) (Derived from U-SCHEMA-METHOD-001, Rule 1.4)
 A Table of Contents (ToC) MUST follow the abstract, linking to all H2 sections and significant H3 sections.
-*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] for ToC requirements.
+*   **Reference:** See [[AS-STRUCTURE-DOC-CHAPTER]] for ToC requirements.
 
 ## 3. Required Sections (H2 Level) (Derived from U-SCHEMA-METHOD-001, Rule 1.5)
 
@@ -148,13 +148,13 @@ To identify, appraise, and synthesize all relevant studies on a particular topic
 (Summary of the systematic literature review process...)
 
 ## See Also
-- [[CS-POLICY-LAYERED-INFORMATION_ID_PLACEHOLDER]]
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]]
+- [[CS-POLICY-LAYERED-INFORMATION]]
+- [[AS-STRUCTURE-DOC-CHAPTER]]
 ```
 
 ## 6. Cross-References
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - For general chapter structure requirements (H1, abstract, ToC, summary, see also).
-- [[CS-POLICY-LAYERED-INFORMATION_ID_PLACEHOLDER]] - For principles of presenting information from general to specific.
+- [[AS-STRUCTURE-DOC-CHAPTER]] - For general chapter structure requirements (H1, abstract, ToC, summary, see also).
+- [[CS-POLICY-LAYERED-INFORMATION]] - For principles of presenting information from general to specific.
 
 ---
 *This standard (AS-SCHEMA-METHODOLOGY-DESCRIPTION) is based on rules 1.1 through 1.7 previously defined in U-SCHEMA-METHOD-001 from COL-CONTENT-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-STRUCTURE-ASSET-ORGANIZATION.md
+++ b/master-knowledge-base/standards/src/AS-STRUCTURE-ASSET-ORGANIZATION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Asset File Organization" # As per prompt
-related-standards: ["SF-CONVENTIONS-NAMING_ID_PLACEHOLDER", "SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER", "AS-KB-DIRECTORY-STRUCTURE_ID_PLACEHOLDER"]
+related-standards: ["SF-CONVENTIONS-NAMING", "SF-ACCESSIBILITY-IMAGE-ALT-TEXT", "AS-KB-DIRECTORY-STRUCTURE"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -33,7 +33,7 @@ This standard defines the requirements for organizing, categorizing, naming, and
 ### Rule 2.1: Top-Level `assets` Folder (Derived from U-ASSETS-001, Rule 1.1)
 All non-Markdown assets associated with a specific Knowledge Base MUST reside in a dedicated top-level folder named `assets` directly within that KB's primary folder.
 *   **Example:** If a KB's primary folder is `my-awesome-kb/`, then all its assets MUST be placed within `my-awesome-kb/assets/`.
-*   **Rationale:** Centralizes all non-Markdown resources for a KB, making them easy to locate and manage. This is consistent with the overall KB directory structure outlined in [[AS-KB-DIRECTORY-STRUCTURE_ID_PLACEHOLDER]].
+*   **Rationale:** Centralizes all non-Markdown resources for a KB, making them easy to locate and manage. This is consistent with the overall KB directory structure outlined in [[AS-KB-DIRECTORY-STRUCTURE]].
 
 ## 3. Asset Categorization
 
@@ -46,13 +46,13 @@ Within the `assets` folder, sub-folders SHOULD be used to categorize assets base
     *   `code-snippets/` (for external code files like `.py`, `.js`, `.sql` that are referenced or meant to be downloadable, not for embedded code in Markdown)
     *   Other categories as needed (e.g., `data/` for CSV files, `audio/` for audio clips).
 *   **Example:** `my-awesome-kb/assets/images/user-interface-screenshot.png`, `my-awesome-kb/assets/pdfs/annual-report-2023.pdf`
-*   **Folder Naming:** Sub-folder names MUST adhere to the folder naming conventions defined in [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] (all lowercase kebab-case).
+*   **Folder Naming:** Sub-folder names MUST adhere to the folder naming conventions defined in [[SF-CONVENTIONS-NAMING]] (all lowercase kebab-case).
 *   **Rationale:** Categorization improves the organization of the `assets` folder, making it easier to find and manage specific types of assets, especially in KBs with many assets.
 
 ## 4. Asset File Naming
 
 ### Rule 4.1: Descriptive Kebab-Case Names (Derived from U-ASSETS-001, Rule 1.3)
-Asset file names MUST be descriptive of the asset's content or purpose and MUST adhere to the general file naming conventions (all lowercase kebab-case) defined in [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]].
+Asset file names MUST be descriptive of the asset's content or purpose and MUST adhere to the general file naming conventions (all lowercase kebab-case) defined in [[SF-CONVENTIONS-NAMING]].
 *   **Example:** `q1-sales-report.pdf`, `user-flow-diagram.svg`, `api-request-example.py`
 *   **Avoid:** Generic names like `image1.png`, `document.pdf`, or names with spaces or special characters (other than hyphens).
 *   **Rationale:** Descriptive names make assets easier to identify and manage. Consistent kebab-casing ensures cross-platform compatibility and predictability.
@@ -86,9 +86,9 @@ The following image formats are permitted for use within the knowledge base:
 This standard applies to all non-Markdown files that are part of a Knowledge Base and are stored within its designated `assets` folder.
 
 ## 8. Cross-References
-- [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] - For general file and folder naming conventions.
-- [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]] - For requirements related to the accessibility of images.
-- [[AS-KB-DIRECTORY-STRUCTURE_ID_PLACEHOLDER]] - For the overall KB directory structure, including the location of the KB-specific `assets` folder.
+- [[SF-CONVENTIONS-NAMING]] - For general file and folder naming conventions.
+- [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]] - For requirements related to the accessibility of images.
+- [[AS-KB-DIRECTORY-STRUCTURE]] - For the overall KB directory structure, including the location of the KB-specific `assets` folder.
 
 ---
 *This standard (AS-STRUCTURE-ASSET-ORGANIZATION) is based on rules 1.1 through 1.4 previously defined in U-ASSETS-001 from COL-LINKING-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-STRUCTURE-DOC-CHAPTER.md
+++ b/master-knowledge-base/standards/src/AS-STRUCTURE-DOC-CHAPTER.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Document Chapter Structure"
-related-standards: ["CS-POLICY-DOC-CHAPTER-CONTENT", "SF-SYNTAX-HEADINGS_ID_PLACEHOLDER", "SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER"]
+related-standards: ["CS-POLICY-DOC-CHAPTER-CONTENT", "SF-SYNTAX-HEADINGS", "SF-LINKS-INTERNAL-SYNTAX"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -31,7 +31,7 @@ This standard defines the mandatory internal structure for primary content docum
 ### Rule 1.1: Single H1 Heading (Derived from U-STRUC-002, Rule 2.1)
 Every "Chapter" document MUST begin with an H1 heading, which serves as the document title. This MUST be the only H1 heading within the document.
 *   **Example:** `# My Chapter Title`
-*   **Notes:** This rule is fundamental for semantic structure and document parsing. Adherence to [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]] is required.
+*   **Notes:** This rule is fundamental for semantic structure and document parsing. Adherence to [[SF-SYNTAX-HEADINGS]] is required.
 
 ### Rule 1.2: Topic Abstract (Derived from U-STRUC-002, Rule 2.2)
 An introductory "Topic Abstract," typically 1-3 paragraphs long, MUST immediately follow the H1 heading.
@@ -49,7 +49,7 @@ A Table of Contents (ToC) MUST follow the Topic Abstract. This ToC should link t
     ```
 *   **Notes:**
     *   Manual creation of the ToC or the use of a user's chosen authoring tool/plugin is acceptable. The key is the presence and accuracy of the ToC.
-    *   Links MUST use the syntax defined in [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]].
+    *   Links MUST use the syntax defined in [[SF-LINKS-INTERNAL-SYNTAX]].
 
 ### Rule 1.4: Concluding "Summary" Section (Derived from U-STRUC-002, Rule 2.6)
 A concluding section, typically titled "Summary" and formatted as an H2 heading, MUST be included at the end of the main content.
@@ -65,7 +65,7 @@ If relevant cross-references exist, a section titled "See Also" and formatted as
     - [[ANOTHER-RELEVANT-STANDARD_ID_PLACEHOLDER]]
     ```
 *   **Content:** This section should contain a list of links to related documents, standards, or sections that provide further context or information.
-*   **Notes:** Links MUST use the syntax defined in [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]]. If no relevant cross-references exist, this section may be omitted.
+*   **Notes:** Links MUST use the syntax defined in [[SF-LINKS-INTERNAL-SYNTAX]]. If no relevant cross-references exist, this section may be omitted.
 
 ## 2. Illustrative Example
 
@@ -102,9 +102,9 @@ This chapter provided an overview of research methodology, defined key terms, an
 
 ## 3. Cross-References
 - [[CS-POLICY-DOC-CHAPTER-CONTENT]] - Policy for content organization and heading usage within Chapters.
-- [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]] - Standard for Markdown Heading Syntax.
-- [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] - Standard for Internal Linking Syntax.
-- [[U-FORMAT-NAMING_ID_PLACEHOLDER]] - File and Folder Naming Conventions (if relevant to chapter file naming).
+- [[SF-SYNTAX-HEADINGS]] - Standard for Markdown Heading Syntax.
+- [[SF-LINKS-INTERNAL-SYNTAX]] - Standard for Internal Linking Syntax.
+- [[SF-CONVENTIONS-NAMING]] - File and Folder Naming Conventions (if relevant to chapter file naming).
 
 ---
 *This standard (AS-STRUCTURE-DOC-CHAPTER) is based on rules 2.1, 2.2, 2.3, 2.6, and 2.7 previously defined in U-STRUC-002 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-STRUCTURE-KB-PART.md
+++ b/master-knowledge-base/standards/src/AS-STRUCTURE-KB-PART.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "KB Part Structure"
-related-standards: ["CS-POLICY-KB-PART-CONTENT", "AS-STRUCTURE-KB-ROOT", "SF-CONVENTIONS-NAMING_ID_PLACEHOLDER"]
+related-standards: ["CS-POLICY-KB-PART-CONTENT", "AS-STRUCTURE-KB-ROOT", "SF-CONVENTIONS-NAMING"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -35,7 +35,7 @@ Each "Part" (top-level primary section of a KB) MUST be fronted by an overview.
 ### Rule 1.2: Overview Location for Sub-folder Parts (Derived from U-STRUC-001, Rule 1.2)
 If "Parts" are implemented as sub-folders (typically for larger KBs, as defined in [[AS-STRUCTURE-KB-ROOT]]), the overview content MUST reside in an `_overview.md` file located directly within that Part's folder.
 *   **Example:** `research-methodology-kb/part-i-foundations/_overview.md`
-*   **Notes:** The filename `_overview.md` is mandatory and MUST adhere to naming conventions in [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]].
+*   **Notes:** The filename `_overview.md` is mandatory and MUST adhere to naming conventions in [[SF-CONVENTIONS-NAMING]].
 
 ### Rule 1.3: Overview Location for `root.md` Section Parts (Derived from U-STRUC-001, Rule 1.3)
 If "Parts" are implemented as major H1 sections within the `root.md` file (typically for smaller KBs, as defined in [[AS-STRUCTURE-KB-ROOT]]), the overview content and links to its "Chapters" MUST directly follow the Part's H1 heading in `root.md`.
@@ -80,9 +80,9 @@ This part lays the groundwork for understanding the core principles and initial 
 ## 3. Cross-References
 - [[CS-POLICY-KB-PART-CONTENT]] - Policy for content organization within KB Parts.
 - [[AS-STRUCTURE-KB-ROOT]] - Defines the overall structure for KB root files and how Parts are organized.
-- [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] - File and Folder Naming Conventions (relevant for `_overview.md` and Part folder names).
+- [[SF-CONVENTIONS-NAMING]] - File and Folder Naming Conventions (relevant for `_overview.md` and Part folder names).
 - [[SF-LINKS-INTERNAL-SYNTAX]] - Internal Linking Syntax Standard.
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - Standard for Content Document ("Chapter") Internal Structure (to be updated with actual ID).
+- [[AS-STRUCTURE-DOC-CHAPTER]] - Standard for Content Document ("Chapter") Internal Structure (to be updated with actual ID).
 
 ---
 *This standard (AS-STRUCTURE-KB-PART) is based on rules 1.1, 1.2, 1.3, and 1.4 previously defined in U-STRUC-001 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-STRUCTURE-KB-ROOT.md
+++ b/master-knowledge-base/standards/src/AS-STRUCTURE-KB-ROOT.md
@@ -31,7 +31,7 @@ This standard defines the mandatory structure for the root level of any Knowledg
 ### Rule 1.1: Designated Primary Folder
 Each Knowledge Base (KB) MUST have a designated primary folder.
 *   **Example:** `prompt-engineering-kb/`
-*   **Notes:** Folder naming MUST adhere to [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]].
+*   **Notes:** Folder naming MUST adhere to [[SF-CONVENTIONS-NAMING]].
 
 ### Rule 1.2: Root Document (`root.md`)
 Within this primary folder, a root document named `root.md` MUST exist.
@@ -45,7 +45,7 @@ The `root.md` file MUST contain a master Table of Contents (ToC) that links to a
 ### Rule 1.4: Top-Level "Parts" in Larger KBs (Sub-folders)
 For **larger KBs**, top-level "Parts" (primary sections) MUST be implemented as distinct sub-folders within the primary KB folder. Each such sub-folder represents one "Part".
 *   **Example:** `research-methodology-kb/part-i-foundations/`
-*   **Notes:** Folder naming MUST adhere to [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]]. The decision criterion for "larger" versus "smaller" is further discussed in [[CS-POLICY-KB-ROOT]].
+*   **Notes:** Folder naming MUST adhere to [[SF-CONVENTIONS-NAMING]]. The decision criterion for "larger" versus "smaller" is further discussed in [[CS-POLICY-KB-ROOT]].
 
 ### Rule 1.5: Top-Level "Parts" in Smaller KBs (`root.md` Sections)
 For **smaller or moderately sized KBs**, top-level "Parts" (primary sections) MUST be major H1 sections (often rendered as H2 in the context of the `root.md` document itself, following the main H1 title of `root.md`) directly within the `root.md` file. Content for these Parts can be nested directly or linked to subordinate files within the same primary KB folder.
@@ -80,9 +80,9 @@ This knowledge base provides comprehensive guidance on research methodologies...
 ## 3. Cross-References
 - [[CS-POLICY-KB-ROOT]] - Policy for consistent application of KB root structures.
 - [[AS-KB-DIRECTORY-STRUCTURE]] - Defines overall repository and master knowledge base directory structures.
-- [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] - File and Folder Naming Conventions (to be updated with actual ID).
+- [[SF-CONVENTIONS-NAMING]] - File and Folder Naming Conventions (to be updated with actual ID).
 - [[SF-LINKS-INTERNAL-SYNTAX]] - Internal Linking Syntax Standard.
-- [[U-STRUC-001_ID_PLACEHOLDER]] - Primary KB Section ("Part") Structure (to be updated with actual ID).
+- [[AS-STRUCTURE-KB-PART]] - Primary KB Section ("Part") Structure (to be updated with actual ID).
 
 ---
 *This standard (AS-STRUCTURE-KB-ROOT) is based on rules 1.1-1.5 previously defined in U-ARCH-001 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-STRUCTURE-MASTER-KB-INDEX.md
+++ b/master-knowledge-base/standards/src/AS-STRUCTURE-MASTER-KB-INDEX.md
@@ -68,7 +68,7 @@ This directory provides an overview and access points to all active Knowledge Ba
 - [[CS-POLICY-KB-IDENTIFICATION]] - Policy for unique KB identification and naming.
 - [[AS-KB-DIRECTORY-STRUCTURE]] - Defines the broader repository and `master-knowledge-base` directory structures.
 - [[SF-LINKS-INTERNAL-SYNTAX]] - Internal Linking Syntax Standard.
-- [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] - File and Folder Naming Conventions (to be updated with actual ID, relevant for KB folder names).
+- [[SF-CONVENTIONS-NAMING]] - File and Folder Naming Conventions (to be updated with actual ID, relevant for KB folder names).
 
 ---
 *This standard (AS-STRUCTURE-MASTER-KB-INDEX) is based on rules 2.1, 2.3, and 2.4 previously defined in U-ARCH-002 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/AS-STRUCTURE-TEMPLATES-DIRECTORY.md
+++ b/master-knowledge-base/standards/src/AS-STRUCTURE-TEMPLATES-DIRECTORY.md
@@ -10,10 +10,10 @@ kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Templates Directory and Usage" # As per prompt
 related-standards: [
-  "AS-KB-DIRECTORY-STRUCTURE_ID_PLACEHOLDER",
-  "AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER",
-  "AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER",
-  "tpl-canonical-frontmatter_ID_PLACEHOLDER"
+  "AS-KB-DIRECTORY-STRUCTURE",
+  "AS-SCHEMA-METHODOLOGY-DESCRIPTION",
+  "AS-SCHEMA-CONCEPT-DEFINITION",
+  "tpl-canonical-frontmatter.md"
 ]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
@@ -37,20 +37,20 @@ This standard defines the requirements for the creation, maintenance, and conten
 
 ### Rule 2.1: Dedicated Templates Directory (Derived from U-TEMPLATES-DIR-001, Rule 1.1, adapted)
 A dedicated directory for housing standard document templates MUST be maintained at the following path: `/master-knowledge-base/standards/templates/`.
-*   **Rationale:** Centralizes templates for easy discovery and consistent application across the knowledge base. This specific path aligns with the established directory structure for standards-related resources (see [[AS-KB-DIRECTORY-STRUCTURE_ID_PLACEHOLDER]]).
+*   **Rationale:** Centralizes templates for easy discovery and consistent application across the knowledge base. This specific path aligns with the established directory structure for standards-related resources (see [[AS-KB-DIRECTORY-STRUCTURE]]).
 *   **Notes:** This directory was established in Phase 0 (Task 0.4.3).
 
 ### Rule 2.2: Content of the Templates Directory (Derived from U-TEMPLATES-DIR-001, Rule 1.2)
 The `/master-knowledge-base/standards/templates/` directory MUST contain Markdown template files (`.md`) for common standard document types. These templates are intended to:
-    a.  Pre-fill the basic structure of a new document according to relevant `AS-SCHEMA-*` (Architectural Standard - Schema) documents, such as [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]] and [[AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER]].
+    a.  Pre-fill the basic structure of a new document according to relevant `AS-SCHEMA-*` (Architectural Standard - Schema) documents, such as [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]] and [[AS-SCHEMA-CONCEPT-DEFINITION]].
     b.  Include placeholder content or comments to guide authors on filling out various sections.
-    c.  May also include utility templates, such as a canonical frontmatter template (e.g., [[tpl-canonical-frontmatter_ID_PLACEHOLDER]], which was created in Phase 0, Task 0.4.3).
+    c.  May also include utility templates, such as a canonical frontmatter template (e.g., [[tpl-canonical-frontmatter.md]], which was created in Phase 0, Task 0.4.3).
 
 *   **Examples of Templates:**
     *   `tpl-standard-definition.md`
     *   `tpl-policy-document.md`
-    *   `tpl-methodology-schema.md` (based on [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]])
-    *   `tpl-concept-schema.md` (based on [[AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER]])
+    *   `tpl-methodology-schema.md` (based on [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]])
+    *   `tpl-concept-schema.md` (based on [[AS-SCHEMA-CONCEPT-DEFINITION]])
     *   `tpl-canonical-frontmatter.md`
 
 ### Rule 2.3: Template Naming Convention
@@ -70,10 +70,10 @@ All template filenames within the `/master-knowledge-base/standards/templates/` 
 This standard applies to the management of the templates directory and the creation of new templates. Authors creating new standard documents are strongly encouraged to use these templates.
 
 ## 5. Cross-References
-- [[AS-KB-DIRECTORY-STRUCTURE_ID_PLACEHOLDER]] - Defines the overall location of the `/master-knowledge-base/standards/templates/` directory.
-- [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]] - An example of a schema for which a template should exist.
-- [[AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER]] - Another example of a schema for which a template should exist.
-- [[tpl-canonical-frontmatter_ID_PLACEHOLDER]] - Reference to the existing canonical frontmatter template. (Note: This is a direct reference to a template file, not a standard. It's included as it's a key example of a utility template.)
+- [[AS-KB-DIRECTORY-STRUCTURE]] - Defines the overall location of the `/master-knowledge-base/standards/templates/` directory.
+- [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]] - An example of a schema for which a template should exist.
+- [[AS-SCHEMA-CONCEPT-DEFINITION]] - Another example of a schema for which a template should exist.
+- [[tpl-canonical-frontmatter.md]] - Reference to the existing canonical frontmatter template. (Note: This is a direct reference to a template file, not a standard. It's included as it's a key example of a utility template.)
 
 ---
 *This standard (AS-STRUCTURE-TEMPLATES-DIRECTORY) is based on rules 1.1 and 1.2 previously defined in U-TEMPLATES-DIR-001 from COL-GOVERNANCE-UNIVERSAL.md, adapting them for the new directory structure and emphasizing established naming conventions.*

--- a/master-knowledge-base/standards/src/CS-ADMONITIONS-POLICY.md
+++ b/master-knowledge-base/standards/src/CS-ADMONITIONS-POLICY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Admonition and Callout Usage Policy" # As per prompt
-related-standards: ["SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER"]
+related-standards: ["SF-CALLOUTS-SYNTAX"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,16 +26,16 @@ change_log_url: "./CS-ADMONITIONS-POLICY-changelog.md" # Placeholder
 
 ## 1. Policy Statement
 
-This policy governs the appropriate and semantic use of admonition/callout blocks, whose syntax is defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]]. Admonitions are designed to draw the reader's attention to specific pieces of information that are ancillary or supplementary to the main text, or that require special emphasis (e.g., warnings, tips). Proper and consistent use of admonitions enhances readability and user experience.
+This policy governs the appropriate and semantic use of admonition/callout blocks, whose syntax is defined in [[SF-CALLOUTS-SYNTAX]]. Admonitions are designed to draw the reader's attention to specific pieces of information that are ancillary or supplementary to the main text, or that require special emphasis (e.g., warnings, tips). Proper and consistent use of admonitions enhances readability and user experience.
 
 ## 2. Core Usage Policies for Admonitions/Callouts
 
 ### Rule 2.1: Semantic Use of `TYPE`
-Admonition blocks MUST be used semantically, meaning the chosen `[!TYPE]` keyword (as defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]]) MUST accurately reflect the nature and purpose of the information being highlighted.
+Admonition blocks MUST be used semantically, meaning the chosen `[!TYPE]` keyword (as defined in [[SF-CALLOUTS-SYNTAX]]) MUST accurately reflect the nature and purpose of the information being highlighted.
 *   **Rationale:** Semantic usage ensures that the visual cues (colors, icons, etc.) provided by the rendered callout align with the content's intent, creating a consistent and predictable experience for the user.
 
 ### Rule 2.2: Guidance on Common `TYPE` Keywords
-The following provides guidance on when to use the common `TYPE` keywords defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]]:
+The following provides guidance on when to use the common `TYPE` keywords defined in [[SF-CALLOUTS-SYNTAX]]:
 
 *   **`[!NOTE]`**: For supplementary information that is relevant but tangential to the main text. Useful for elaborations, side comments, or additional context.
 *   **`[!IMPORTANT]`**: For information that users must not overlook due to its significance for understanding or correct application of the main content.
@@ -59,7 +59,7 @@ If an optional title is used after the `[!TYPE]` specifier, it SHOULD be concise
 *   **Rationale:** A good title provides immediate context for the callout's content.
 
 ### Rule 2.4: Content Indentation
-All content within a callout block, including multiple paragraphs, lists, or other Markdown elements, MUST be correctly indented to align under the callout's initial `>` marker, as specified in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]] and [[SF-SYNTAX-BLOCKQUOTES_ID_PLACEHOLDER]].
+All content within a callout block, including multiple paragraphs, lists, or other Markdown elements, MUST be correctly indented to align under the callout's initial `>` marker, as specified in [[SF-CALLOUTS-SYNTAX]] and [[SF-SYNTAX-BLOCKQUOTES]].
 *   **Rationale:** Ensures correct rendering of the callout as a single, cohesive block.
 
 ### Rule 2.5: Avoid Overuse
@@ -80,9 +80,9 @@ Admonition blocks SHOULD be used judiciously and only when information genuinely
 This policy applies to all authors and editors creating or modifying content within the knowledge base. It guides the decision-making process for when and how to use admonition/callout blocks.
 
 ## 5. Cross-References
-- [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]] - Defines the Markdown syntax for creating callout/admonition blocks.
-- [[SF-SYNTAX-BLOCKQUOTES_ID_PLACEHOLDER]] - Defines the base blockquote syntax.
+- [[SF-CALLOUTS-SYNTAX]] - Defines the Markdown syntax for creating callout/admonition blocks.
+- [[SF-SYNTAX-BLOCKQUOTES]] - Defines the base blockquote syntax.
 
 ---
-*This policy (CS-ADMONITIONS-POLICY) provides guidance on the semantic and appropriate use of the callout/admonition syntax defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]], generalizing concepts from previous tool-specific standards like O-USAGE-CALLOUTS-001.*
+*This policy (CS-ADMONITIONS-POLICY) provides guidance on the semantic and appropriate use of the callout/admonition syntax defined in [[SF-CALLOUTS-SYNTAX]], generalizing concepts from previous tool-specific standards like O-USAGE-CALLOUTS-001.*
 ```

--- a/master-knowledge-base/standards/src/CS-CONTENT-PROFILING-POLICY.md
+++ b/master-knowledge-base/standards/src/CS-CONTENT-PROFILING-POLICY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Content Profiling Strategy" # As per prompt
-related-standards: ["SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER", "SF-CONDITIONAL-SYNTAX-ATTRIBUTES_ID_PLACEHOLDER"]
+related-standards: ["SF-CALLOUTS-SYNTAX", "SF-CONDITIONAL-SYNTAX-ATTRIBUTES"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -39,22 +39,22 @@ Content profiling and conditional text serve several key purposes:
 ## 3. Implementation of Conditional Text
 
 ### Rule 3.1: Use of `[!IF condition]` Callouts (Derived from M-CONDITIONAL-TEXT-SYNTAX-001, Rule 1.1)
-Conditional text blocks MUST be implemented using the `[!IF condition]` callout syntax as defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]].
+Conditional text blocks MUST be implemented using the `[!IF condition]` callout syntax as defined in [[SF-CALLOUTS-SYNTAX]].
 *   **Syntax Reminder:** `> [!IF condition]`
 *   **Rationale:** Provides a standardized and visually distinct way to mark conditional content.
 
 ### Rule 3.2: Condition String Syntax
-The `condition` string within the `[!IF condition]` callout MUST adhere to the syntax defined in [[SF-CONDITIONAL-SYNTAX-ATTRIBUTES_ID_PLACEHOLDER]].
+The `condition` string within the `[!IF condition]` callout MUST adhere to the syntax defined in [[SF-CONDITIONAL-SYNTAX-ATTRIBUTES]].
 *   **Syntax Reminder:** Conditions are `attribute=value` pairs, combinable with `AND` (case-insensitive). `OR` logic requires separate blocks. Attribute names and values must not contain spaces; values should use kebab-case for multiple words.
 *   **Rationale:** Ensures conditions are parsable and consistently interpreted.
 
 ### Rule 3.3: Content Indentation and Structure (Derived from M-CONDITIONAL-TEXT-SYNTAX-001, Rules 1.4 & 1.5)
-All content that is conditional upon the `IF` statement MUST be correctly indented under the callout, following standard callout content rules as specified in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]].
+All content that is conditional upon the `IF` statement MUST be correctly indented under the callout, following standard callout content rules as specified in [[SF-CALLOUTS-SYNTAX]].
 *   **Guidance:** Conditional blocks can span multiple paragraphs, lists, or other Markdown elements, as long as each line of the conditional content starts with the callout marker (`> `) and appropriate indentation for nested elements within the callout.
 *   **Rationale:** Ensures correct rendering and association of content with its condition.
 
 ### Rule 3.4: Blank Lines Around Conditional Blocks (Derived from M-CONDITIONAL-TEXT-SYNTAX-001, Rule 1.6)
-A blank line SHOULD precede and follow a conditional block for readability, unless it is immediately followed by another related conditional block (e.g., a series of mutually exclusive conditions). This aligns with [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]].
+A blank line SHOULD precede and follow a conditional block for readability, unless it is immediately followed by another related conditional block (e.g., a series of mutually exclusive conditions). This aligns with [[SF-FORMATTING-FILE-HYGIENE]].
 *   **Rationale:** Improves visual separation and parsing reliability.
 
 ## 4. Profiling Attributes and Values (Authoritative Source)
@@ -95,7 +95,7 @@ The following attributes and example values are initially approved for use. Valu
 ### Rule 4.2: Process for Managing Attributes and Values
 *   **Proposal:** New attributes or values, or changes to existing ones, MUST be proposed to the designated governance body (e.g., Editorial Board, Standards Committee).
 *   **Review:** Proposals will be reviewed for clarity, necessity, potential overlap, and impact on the overall profiling strategy.
-*   **Approval & Documentation:** Approved attributes and values will be formally added to this policy document (Rule 4.1). Changes to this section MUST follow the standard versioning and changelog process for this policy document itself, as defined in [[OM-VERSIONING-CHANGELOGS_ID_PLACEHOLDER]].
+*   **Approval & Documentation:** Approved attributes and values will be formally added to this policy document (Rule 4.1). Changes to this section MUST follow the standard versioning and changelog process for this policy document itself, as defined in [[OM-VERSIONING-CHANGELOGS]].
 *   **Rationale:** Ensures that the set of profiling attributes and values remains controlled, consistent, and aligned with the evolving needs of the knowledge base.
 
 ## 5. Illustrative Examples of Conditional Text Usage
@@ -145,9 +145,9 @@ To install the software:
 This policy applies to all content within the knowledge base where conditional text is used for profiling or selective display. All authors and editors MUST adhere to this policy when implementing conditional content.
 
 ## 8. Cross-References
-- [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]] - Defines the general syntax for callout blocks, including the `[!IF ...]` type.
-- [[SF-CONDITIONAL-SYNTAX-ATTRIBUTES_ID_PLACEHOLDER]] - Defines the specific syntax for the condition string within `[!IF ...]` callouts.
-- [[OM-VERSIONING-CHANGELOGS_ID_PLACEHOLDER]] - For versioning this policy document when attributes/values are updated.
+- [[SF-CALLOUTS-SYNTAX]] - Defines the general syntax for callout blocks, including the `[!IF ...]` type.
+- [[SF-CONDITIONAL-SYNTAX-ATTRIBUTES]] - Defines the specific syntax for the condition string within `[!IF ...]` callouts.
+- [[OM-VERSIONING-CHANGELOGS]] - For versioning this policy document when attributes/values are updated.
 
 ---
 *This policy (CS-CONTENT-PROFILING-POLICY) is based on rules 1.1, 1.4, 1.5, and 1.6 previously defined in M-CONDITIONAL-TEXT-SYNTAX-001. It also establishes itself as the new authoritative source for profiling attributes and values, superseding U-PROFILING-ATTRIBUTES-001.*

--- a/master-knowledge-base/standards/src/CS-LINKING-INTERNAL-POLICY.md
+++ b/master-knowledge-base/standards/src/CS-LINKING-INTERNAL-POLICY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Internal Linking Strategy and Best Practices" # As per prompt
-related-standards: ["SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER", "AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER"]
+related-standards: ["SF-LINKS-INTERNAL-SYNTAX", "AS-STRUCTURE-DOC-CHAPTER"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./CS-LINKING-INTERNAL-POLICY-changelog.md" # Placeholder
 
 ## 1. Policy Statement
 
-This policy outlines the strategy and best practices for creating internal links within documents in the Knowledge Base (KB). Effective internal linking is crucial for knowledge discovery, enhancing navigability, creating content cohesion, and improving the overall user experience. All internal links MUST adhere to the syntax defined in [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]].
+This policy outlines the strategy and best practices for creating internal links within documents in the Knowledge Base (KB). Effective internal linking is crucial for knowledge discovery, enhancing navigability, creating content cohesion, and improving the overall user experience. All internal links MUST adhere to the syntax defined in [[SF-LINKS-INTERNAL-SYNTAX]].
 
 ## 2. Core Linking Policies
 
@@ -37,11 +37,11 @@ Internal links between documents, notes, and specific sections within the same K
 ### Rule 2.2: Descriptive Link Text (Derived from U-INTERLINK-001, Rule 1.3)
 Link text MUST be descriptive and clearly indicate the nature of the target content.
 *   **Guidance for `[[STANDARD_ID]]` or `[[filename]]` style links:** If the raw `STANDARD_ID` or filename (used as link text by default in some syntaxes) is not sufficiently descriptive for the context, an alias or display text MUST be used.
-    *   **Example:** Instead of just `See [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]].`, prefer `For detailed syntax rules, see the [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER|Internal Linking Syntax Standard]].`
+    *   **Example:** Instead of just `See [[SF-LINKS-INTERNAL-SYNTAX]].`, prefer `For detailed syntax rules, see the [[SF-LINKS-INTERNAL-SYNTAX|Internal Linking Syntax Standard]].`
 *   **Rationale:** Descriptive link text improves scannability, accessibility (for screen reader users), and helps users decide whether to follow a link by providing clear context about the destination.
 
 ### Rule 2.3: "See Also" Sections for Grouped Links (Derived from U-INTERLINK-001, Rule 1.4)
-"See Also" sections, as defined in [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]], ARE a primary and mandatory mechanism for grouping links to related documents, standards, or external resources at the end of a document.
+"See Also" sections, as defined in [[AS-STRUCTURE-DOC-CHAPTER]], ARE a primary and mandatory mechanism for grouping links to related documents, standards, or external resources at the end of a document.
 *   **Rationale:** Provides a dedicated and consistent location for users to find further relevant information, acting as a curated list of related readings or next steps.
 
 ### Rule 2.4: Contextual Relevance and Avoidance of Over-Linking (Derived from U-INTERLINK-001, Rule 1.5)
@@ -54,7 +54,7 @@ Links embedded within the main body of the text MUST be contextually relevant to
 
 ## 3. Adherence to Link Syntax Standard
 
-All internal links, regardless of the specific linking strategy employed, MUST strictly adhere to the syntactical rules defined in [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]]. This ensures consistency, maintainability, and allows for potential automated processing or validation of links.
+All internal links, regardless of the specific linking strategy employed, MUST strictly adhere to the syntactical rules defined in [[SF-LINKS-INTERNAL-SYNTAX]]. This ensures consistency, maintainability, and allows for potential automated processing or validation of links.
 
 ## 4. Rationale for Linking Policy
 
@@ -71,9 +71,9 @@ A coherent internal linking strategy provides significant benefits:
 This policy applies to all content creators, editors, and curators working within any Knowledge Base in the repository. It governs the creation and maintenance of all internal links.
 
 ## 6. Cross-References
-- [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] - Defines the mandatory syntax for internal links.
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - Defines the requirement for "See Also" sections in documents.
+- [[SF-LINKS-INTERNAL-SYNTAX]] - Defines the mandatory syntax for internal links.
+- [[AS-STRUCTURE-DOC-CHAPTER]] - Defines the requirement for "See Also" sections in documents.
 
 ---
-*This policy (CS-LINKING-INTERNAL-POLICY) is based on rules 1.1, 1.3, 1.4, and 1.5 previously defined in U-INTERLINK-001 from COL-LINKING-UNIVERSAL.md. Rule 1.2 regarding syntax is now covered by [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]].*
+*This policy (CS-LINKING-INTERNAL-POLICY) is based on rules 1.1, 1.3, 1.4, and 1.5 previously defined in U-INTERLINK-001 from COL-LINKING-UNIVERSAL.md. Rule 1.2 regarding syntax is now covered by [[SF-LINKS-INTERNAL-SYNTAX]].*
 ```

--- a/master-knowledge-base/standards/src/CS-MODULARITY-TRANSCLUSION-POLICY.md
+++ b/master-knowledge-base/standards/src/CS-MODULARITY-TRANSCLUSION-POLICY.md
@@ -10,10 +10,10 @@ kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Content Modularity and Transclusion" # As per prompt
 related-standards: [
-  "SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDER",
-  "AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER",
-  "AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER",
-  "CS-LINKING-INTERNAL-POLICY_ID_PLACEHOLDER"
+  "SF-TRANSCLUSION-SYNTAX",
+  "AS-SCHEMA-METHODOLOGY-DESCRIPTION",
+  "AS-SCHEMA-CONCEPT-DEFINITION",
+  "CS-LINKING-INTERNAL-POLICY"
 ]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
@@ -31,7 +31,7 @@ change_log_url: "./CS-MODULARITY-TRANSCLUSION-POLICY-changelog.md" # Placeholder
 
 ## 1. Policy Statement
 
-This policy promotes the design of content for modularity and governs the appropriate use of transclusion (content embedding) as defined in [[SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDER]]. The goal is to foster content reusability, improve maintainability, ensure consistency, and adhere to the "Don't Repeat Yourself" (DRY) principle.
+This policy promotes the design of content for modularity and governs the appropriate use of transclusion (content embedding) as defined in [[SF-TRANSCLUSION-SYNTAX]]. The goal is to foster content reusability, improve maintainability, ensure consistency, and adhere to the "Don't Repeat Yourself" (DRY) principle.
 
 ## 2. Core Policies for Modularity and Transclusion
 
@@ -39,12 +39,12 @@ This policy promotes the design of content for modularity and governs the approp
 Content pertaining to distinct concepts, methodologies, processes, or key steps SHOULD be designed to be as atomic and self-contained as possible.
 *   **Guidance:**
     *   Each document or major section should focus on a specific, well-defined topic.
-    *   Minimize "context bleeding" from unrelated surrounding topics within the same content chunk. If context from other documents is needed, prefer linking using [[CS-LINKING-INTERNAL-POLICY_ID_PLACEHOLDER]] rather than extensive repetition.
-    *   This aligns with the principles behind specific content schemas like [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]] and [[AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER]], which encourage focused content.
+    *   Minimize "context bleeding" from unrelated surrounding topics within the same content chunk. If context from other documents is needed, prefer linking using [[CS-LINKING-INTERNAL-POLICY]] rather than extensive repetition.
+    *   This aligns with the principles behind specific content schemas like [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]] and [[AS-SCHEMA-CONCEPT-DEFINITION]], which encourage focused content.
 *   **Rationale:** Atomic content is easier to understand in isolation, reuse in different contexts (including via transclusion), and maintain independently.
 
 ### Rule 2.2: Use Transclusion to Avoid Duplication (Derived from U-MODULAR-001, Rule 1.2)
-Transclusion, using the syntax defined in [[SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDER]], MUST be used instead of duplicating substantial, identical blocks of common content across multiple documents.
+Transclusion, using the syntax defined in [[SF-TRANSCLUSION-SYNTAX]], MUST be used instead of duplicating substantial, identical blocks of common content across multiple documents.
 *   **Examples of "substantial common content":**
     *   Sets of core principles applicable to multiple methodologies.
     *   Standard disclaimers, warnings, or introductory paragraphs.
@@ -57,14 +57,14 @@ Transclusion, using the syntax defined in [[SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDE
 Choosing between transclusion and simple linking requires judgment. Here are some guidelines:
 
 ### Rule 3.1: Linking for Contextual Navigation
-Use standard internal links (see [[CS-LINKING-INTERNAL-POLICY_ID_PLACEHOLDER]]) when:
+Use standard internal links (see [[CS-LINKING-INTERNAL-POLICY]]) when:
 *   Referring to a related but distinct topic that the user might want to explore for more comprehensive understanding.
 *   Pointing to prerequisite knowledge or subsequent steps in a larger workflow.
 *   The referenced content is substantial enough to be its own document or major section, and embedding it would disrupt the flow of the current document.
 *   **Example:** A document on "Advanced Data Analysis" might link to a document defining "Statistical Significance" rather than transcluding the entire definition.
 
 ### Rule 3.2: Transclusion for Seamless Integration of Reusable Content
-Use transclusion (see [[SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDER]]) when:
+Use transclusion (see [[SF-TRANSCLUSION-SYNTAX]]) when:
 *   A specific, relatively small piece of content (e.g., a definition, a set of principles, a specific instruction set, a warning notice) needs to appear *as if it's part of the current document* for clarity or completeness.
 *   The transcluded content is truly identical and intended to be reused verbatim in multiple locations.
 *   The flow of the current document benefits from having that piece of information directly embedded, rather than requiring the user to navigate away.
@@ -88,11 +88,11 @@ While transclusion is powerful for reuse, overuse can lead to documents that are
 This policy applies to all content creators and editors within the knowledge base. It guides decisions on how to structure content for reusability and when to employ transclusion.
 
 ## 6. Cross-References
-- [[SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDER]] - Defines the syntax for embedding content.
-- [[CS-LINKING-INTERNAL-POLICY_ID_PLACEHOLDER]] - Policy for general internal linking.
-- [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]] - Example of a content type that can benefit from modular design.
-- [[AS-SCHEMA-CONCEPT-DEFINITION_ID_PLACEHOLDER]] - Another example of a content type that can be designed for modularity.
+- [[SF-TRANSCLUSION-SYNTAX]] - Defines the syntax for embedding content.
+- [[CS-LINKING-INTERNAL-POLICY]] - Policy for general internal linking.
+- [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]] - Example of a content type that can benefit from modular design.
+- [[AS-SCHEMA-CONCEPT-DEFINITION]] - Another example of a content type that can be designed for modularity.
 
 ---
-*This policy (CS-MODULARITY-TRANSCLUSION-POLICY) is based on rules 1.1, 1.2, and 1.3 previously defined in U-MODULAR-001 from COL-LINKING-UNIVERSAL.md, and provides guidance on applying the syntax defined in [[SF-TRANSCLUSION-SYNTAX_ID_PLACEHOLDER]].*
+*This policy (CS-MODULARITY-TRANSCLUSION-POLICY) is based on rules 1.1, 1.2, and 1.3 previously defined in U-MODULAR-001 from COL-LINKING-UNIVERSAL.md, and provides guidance on applying the syntax defined in [[SF-TRANSCLUSION-SYNTAX]].*
 ```

--- a/master-knowledge-base/standards/src/CS-POLICY-ACCESSIBILITY.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-ACCESSIBILITY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Content Accessibility Principles" # As per prompt
-related-standards: ["SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER", "SF-SYNTAX-HEADINGS_ID_PLACEHOLDER"]
+related-standards: ["SF-ACCESSIBILITY-IMAGE-ALT-TEXT", "SF-SYNTAX-HEADINGS"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -35,8 +35,8 @@ All content creators, editors, and curators MUST strive to ensure that content m
 *   **Rationale:** Ensures a consistent and high-quality experience for all users, regardless of ability.
 
 ### Rule 2.2: Image Accessibility (Reference to Specific Standard)
-All images that convey information MUST be made accessible through the provision of descriptive alternative text (alt text), as mandated by [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]].
-*   **Summary of [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]]:**
+All images that convey information MUST be made accessible through the provision of descriptive alternative text (alt text), as mandated by [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]].
+*   **Summary of [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]]:**
     *   Informational images require descriptive alt text.
     *   Alt text must be concise yet convey the image's purpose and meaning.
     *   Purely decorative images should use empty alt text (`alt=""`) to be ignored by assistive technologies.
@@ -48,7 +48,7 @@ Headings (H1-H6) MUST be used semantically to structure content logically and se
     *   The H1 is reserved for the main document title.
     *   Subsequent headings (H2-H6) must follow a correct hierarchical order (e.g., an H2 followed by H3, not H4). Do not skip heading levels for styling purposes.
     *   Use headings to break up long blocks of text and clearly delineate topics and subtopics.
-*   **Reference:** The specific Markdown syntax for headings is defined in [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]].
+*   **Reference:** The specific Markdown syntax for headings is defined in [[SF-SYNTAX-HEADINGS]].
 *   **Rationale:** Proper heading structure is critical for screen reader users, allowing them to navigate documents efficiently and understand their organization. It also benefits all users by making content more scannable and readable.
 
 ## 3. Future Expansion
@@ -73,8 +73,8 @@ This policy will be expanded over time to incorporate additional accessibility g
 This policy applies to all content within the Knowledge Base and to all individuals involved in its creation, editing, and maintenance.
 
 ## 6. Cross-References
-- [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]] - Specific standard for image alt text.
-- [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]] - Standard defining the syntax and semantic use of headings.
+- [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]] - Specific standard for image alt text.
+- [[SF-SYNTAX-HEADINGS]] - Standard defining the syntax and semantic use of headings.
 
 ---
 *This policy (CS-POLICY-ACCESSIBILITY) incorporates Rule 1.3 from U-ACCESSIBILITY-001 (regarding headings) and sets a general framework for content accessibility, referencing the specific standard created for image alt text.*

--- a/master-knowledge-base/standards/src/CS-POLICY-DIGITAL-ABSTRACTION.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-DIGITAL-ABSTRACTION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Digital Abstraction of Non-Digital Concepts"
-related-standards: ["CS-POLICY-SCOPE-INCLUSION_ID_PLACEHOLDER", "CS-POLICY-SCOPE-EXCLUSION_ID_PLACEHOLDER", "AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER"]
+related-standards: ["CS-POLICY-SCOPE-INCLUSION", "CS-POLICY-SCOPE-EXCLUSION", "AS-SCHEMA-METHODOLOGY-DESCRIPTION"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -31,7 +31,7 @@ This policy provides guidelines for translating methodologies, techniques, or co
 ## 2. Core Principles for Digital Abstraction
 
 ### Rule 2.1: Explicit Exclusion or Abstraction of Non-Digital Aspects (Derived from U-ABSTR-DIGITAL-001, Rule 1.1)
-When a methodology or concept traditionally involves physical real-world actions, direct interpersonal interactions, or ethically sensitive areas that are OUT OF SCOPE for the KB's digital and informational focus (as per [[CS-POLICY-SCOPE-INCLUSION_ID_PLACEHOLDER]] and [[CS-POLICY-SCOPE-EXCLUSION_ID_PLACEHOLDER]]), those aspects MUST be explicitly excluded or clearly abstracted.
+When a methodology or concept traditionally involves physical real-world actions, direct interpersonal interactions, or ethically sensitive areas that are OUT OF SCOPE for the KB's digital and informational focus (as per [[CS-POLICY-SCOPE-INCLUSION]] and [[CS-POLICY-SCOPE-EXCLUSION]]), those aspects MUST be explicitly excluded or clearly abstracted.
 *   **Example:** For a medical diagnostic procedure, a KB focused on data analysis would abstract the physical examination steps, focusing instead on the data inputs (symptoms, test results) and analytical processes. The physical examination itself would be noted as out of scope or handled abstractly (e.g., "patient data collected via standard examination protocols (out of scope for this document)").
 *   **Rationale:** Maintains the KB's focus on digitally manageable information and processes, preventing scope creep into areas it's not designed to cover.
 
@@ -40,7 +40,7 @@ Abstracted methodologies or concepts MUST focus on the information-based process
 *   **Example:** When abstracting a traditional face-to-face interview technique for a KB on qualitative data analysis:
     *   **Focus on:** Designing interview questions, structuring an interview protocol (as a digital document), methods for analyzing transcript data, coding qualitative data.
     *   **Abstract/Exclude:** The nuances of in-person rapport-building, non-verbal cues (unless a method for their digital capture and analysis is within scope).
-*   **Guidance:** The goal is to capture the intellectual and procedural core of the concept that is relevant to the KB's purpose. This is particularly relevant for schemas like [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]], where inputs and outputs of steps are defined.
+*   **Guidance:** The goal is to capture the intellectual and procedural core of the concept that is relevant to the KB's purpose. This is particularly relevant for schemas like [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]], where inputs and outputs of steps are defined.
 *   **Rationale:** Ensures that the KB provides practical, actionable knowledge within its intended digital domain, even when dealing with concepts that have non-digital origins.
 
 ### Rule 2.3: Acknowledge Omission of Critical Out-of-Scope Steps (Derived from U-ABSTR-DIGITAL-001, Rule 1.3)
@@ -63,9 +63,9 @@ Adhering to this policy is important for several reasons:
 This policy applies to all content creators and subject matter experts when documenting methodologies, techniques, processes, or concepts that originate from or include significant non-digital elements, and which are being adapted for inclusion in a Knowledge Base.
 
 ## 5. Cross-References
-- [[CS-POLICY-SCOPE-INCLUSION_ID_PLACEHOLDER]] - Policy on what content should be included in KBs.
-- [[CS-POLICY-SCOPE-EXCLUSION_ID_PLACEHOLDER]] - Policy on what content should be excluded from KBs.
-- [[AS-SCHEMA-METHODOLOGY-DESCRIPTION_ID_PLACEHOLDER]] - Standard schema for methodology descriptions, which will often require digital abstraction.
+- [[CS-POLICY-SCOPE-INCLUSION]] - Policy on what content should be included in KBs.
+- [[CS-POLICY-SCOPE-EXCLUSION]] - Policy on what content should be excluded from KBs.
+- [[AS-SCHEMA-METHODOLOGY-DESCRIPTION]] - Standard schema for methodology descriptions, which will often require digital abstraction.
 
 ---
 *This policy (CS-POLICY-DIGITAL-ABSTRACTION) is based on rules 1.1 through 1.3 previously defined in U-ABSTR-DIGITAL-001 from COL-CONTENT-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-POLICY-DOC-CHAPTER-CONTENT.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-DOC-CHAPTER-CONTENT.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Document Chapter Content Organization"
-related-standards: ["AS-STRUCTURE-DOC-CHAPTER", "SF-SYNTAX-HEADINGS_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-DOC-CHAPTER", "SF-SYNTAX-HEADINGS"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -42,7 +42,7 @@ Content within a "Chapter" document MUST be organized using hierarchical Markdow
     ```
 *   **Notes:**
     *   The H1 heading is reserved for the document title as per [[AS-STRUCTURE-DOC-CHAPTER]].
-    *   Adherence to the specific Markdown syntax for headings defined in [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]] is mandatory.
+    *   Adherence to the specific Markdown syntax for headings defined in [[SF-SYNTAX-HEADINGS]] is mandatory.
 
 ### Rule 2.2: H2 Sections as Major Sub-Topics (Derived from U-STRUC-002, Rule 2.5)
 Each H2 section within a "Chapter" document MUST represent a major sub-topic of that chapter.
@@ -70,7 +70,7 @@ This policy applies to all "Chapter" documents (as defined in [[AS-STRUCTURE-DOC
 
 ## 5. Cross-References
 - [[AS-STRUCTURE-DOC-CHAPTER]] - Defines the overall internal structure for Chapter documents.
-- [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]] - Standard for Markdown Heading Syntax.
+- [[SF-SYNTAX-HEADINGS]] - Standard for Markdown Heading Syntax.
 
 ---
 *This policy (CS-POLICY-DOC-CHAPTER-CONTENT) is based on rules 2.4 and 2.5 previously defined in U-STRUC-002 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-POLICY-KB-IDENTIFICATION.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-KB-IDENTIFICATION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Knowledge Base Identification"
-related-standards: ["AS-STRUCTURE-MASTER-KB-INDEX", "SF-CONVENTIONS-NAMING_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-MASTER-KB-INDEX", "SF-CONVENTIONS-NAMING"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -35,7 +35,7 @@ Each Knowledge Base (KB) primary folder name MUST be globally unique within the 
 *   **Example:** `research-methodology-kb`, `prompt-engineering-kb`
 *   **Notes:**
     *   This primary folder name acts as the de facto unique identifier for the KB at the file system level.
-    *   Folder naming conventions (e.g., case, separators) MUST adhere to the global file and folder naming standard: [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]].
+    *   Folder naming conventions (e.g., case, separators) MUST adhere to the global file and folder naming standard: [[SF-CONVENTIONS-NAMING]].
     *   Uniqueness prevents naming conflicts and ambiguity, ensuring that each KB can be distinctly referenced.
 
 ### Rule 2.2: Consistent KB Identity in `root.md` (Derived from U-ARCH-002, Rule 2.5)
@@ -61,7 +61,7 @@ This policy applies to all Knowledge Bases developed and maintained within the o
 
 ## 5. Cross-References
 - [[AS-STRUCTURE-MASTER-KB-INDEX]] - Defines the structure of the master KB directory and the `kb-directory.md` index file.
-- [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] - File and Folder Naming Conventions (to be updated with actual ID).
+- [[SF-CONVENTIONS-NAMING]] - File and Folder Naming Conventions (to be updated with actual ID).
 
 ---
 *This policy (CS-POLICY-KB-IDENTIFICATION) is based on rules 2.2 and 2.5 previously defined in U-ARCH-002 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-POLICY-KB-PART-CONTENT.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-KB-PART-CONTENT.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "KB Part Content Organization"
-related-standards: ["AS-STRUCTURE-KB-PART", "AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-KB-PART", "AS-STRUCTURE-DOC-CHAPTER", "SF-CONVENTIONS-NAMING"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -34,7 +34,7 @@ This policy mandates that "Chapters" (individual documents or major H2 sections 
 "Chapters" within a "Part" of a Knowledge Base MUST be arranged in a logical sequence.
 *   **Guidance:**
     *   The sequence should support a progressive understanding of the Part's subject matter. This might involve, for example, moving from foundational concepts to more advanced topics, or following a chronological or procedural order where appropriate.
-    *   Sequencing is typically managed by numerical prefixes in filenames (e.g., `01-introduction.md`, `02-core-concepts.md`) as defined in [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]], or by the order of H2 headings if Chapters are sections within a single document (e.g., within `_overview.md` for a very small Part).
+    *   Sequencing is typically managed by numerical prefixes in filenames (e.g., `01-introduction.md`, `02-core-concepts.md`) as defined in [[SF-CONVENTIONS-NAMING]], or by the order of H2 headings if Chapters are sections within a single document (e.g., within `_overview.md` for a very small Part).
     *   The Table of Contents within the Part's overview (defined in [[AS-STRUCTURE-KB-PART]]) MUST reflect this logical sequence.
 
 ### Rule 2.2: Distinct and Coherent Topic per "Chapter" (Derived from U-STRUC-001, Rule 1.6)
@@ -42,7 +42,7 @@ Each "Chapter" file or document (or H2 section if Chapters are not separate file
 *   **Guidance:**
     *   A Chapter should have a clear focus and not attempt to cover too many disparate subjects.
     *   If a topic becomes too large or complex for a single Chapter, it should be broken down into multiple, more focused Chapters.
-    *   The scope of each Chapter should be clearly articulated, often in its introductory section, as per [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]].
+    *   The scope of each Chapter should be clearly articulated, often in its introductory section, as per [[AS-STRUCTURE-DOC-CHAPTER]].
 
 ## 3. Rationale and Importance
 
@@ -61,8 +61,8 @@ This policy applies to the organization of "Chapters" within all "Parts" of all 
 
 ## 5. Cross-References
 - [[AS-STRUCTURE-KB-PART]] - Defines the overall structure of KB Parts and their overviews.
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - Standard for Content Document ("Chapter") Internal Structure (to be updated with actual ID).
-- [[SF-CONVENTIONS-NAMING_ID_PLACEHOLDER]] - File and Folder Naming Conventions (relevant for Chapter sequencing).
+- [[AS-STRUCTURE-DOC-CHAPTER]] - Standard for Content Document ("Chapter") Internal Structure (to be updated with actual ID).
+- [[SF-CONVENTIONS-NAMING]] - File and Folder Naming Conventions (relevant for Chapter sequencing).
 
 ---
 *This policy (CS-POLICY-KB-PART-CONTENT) is based on rules 1.5 and 1.6 previously defined in U-STRUC-001 from COL-ARCH-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-POLICY-PART-OVERVIEW.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-PART-OVERVIEW.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Policy for KB Part Overviews" # As per prompt
-related-standards: ["AS-STRUCTURE-KB-PART_ID_PLACEHOLDER", "AS-STRUCTURE-KB-ROOT_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-KB-PART", "AS-STRUCTURE-KB-ROOT"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,22 +26,22 @@ change_log_url: "./CS-POLICY-PART-OVERVIEW-changelog.md" # Placeholder
 
 ## 1. Policy Statement
 
-This policy mandates that each "Part" (top-level primary section) of a Knowledge Base (KB), as defined in [[AS-STRUCTURE-KB-ROOT_ID_PLACEHOLDER]], MUST be introduced by a dedicated overview. The specific structural and content requirements for this overview (e.g., its filename `_overview.md` when Parts are folders, or its placement within `root.md` for smaller KBs, and its content including scope, purpose, and Table of Contents) are defined in [[AS-STRUCTURE-KB-PART_ID_PLACEHOLDER]].
+This policy mandates that each "Part" (top-level primary section) of a Knowledge Base (KB), as defined in [[AS-STRUCTURE-KB-ROOT]], MUST be introduced by a dedicated overview. The specific structural and content requirements for this overview (e.g., its filename `_overview.md` when Parts are folders, or its placement within `root.md` for smaller KBs, and its content including scope, purpose, and Table of Contents) are defined in [[AS-STRUCTURE-KB-PART]].
 
 ## 2. Core Requirement
 
 ### Rule 2.1: Mandatory Overview for Each KB Part
-Every "Part" within a Knowledge Base, whether implemented as a sub-folder or as a major section within the `root.md` file (see [[AS-STRUCTURE-KB-ROOT_ID_PLACEHOLDER]]), MUST have an associated overview document or section.
-*   **Content and Structure:** The content, naming (e.g., `_overview.md`), and placement of this overview are governed by [[AS-STRUCTURE-KB-PART_ID_PLACEHOLDER]]. This includes:
+Every "Part" within a Knowledge Base, whether implemented as a sub-folder or as a major section within the `root.md` file (see [[AS-STRUCTURE-KB-ROOT]]), MUST have an associated overview document or section.
+*   **Content and Structure:** The content, naming (e.g., `_overview.md`), and placement of this overview are governed by [[AS-STRUCTURE-KB-PART]]. This includes:
     *   A brief explanation of the Part's scope and purpose.
     *   A linked Table of Contents (ToC) to its main sub-sections ("Chapters").
 *   **Rationale:** Part overviews serve as clear entry points to major sections of a KB. They aid navigation by providing context and a roadmap to the content within that Part, helping users understand its structure and quickly locate relevant "Chapters."
 
 ## 3. Tool-Agnostic Nature of this Policy
 
-This policy mandates the *existence* and *purpose* of the Part overview content as defined by [[AS-STRUCTURE-KB-PART_ID_PLACEHOLDER]].
+This policy mandates the *existence* and *purpose* of the Part overview content as defined by [[AS-STRUCTURE-KB-PART]].
 *   **Display and Interaction:** How a Part overview (e.g., an `_overview.md` file acting as a "folder note") is displayed or interacted with (for instance, a feature where clicking a folder in a file tree opens its associated `_overview.md` note) is considered a tool-specific enhancement or feature of the authoring/publishing platform.
-*   **Focus of this Policy:** This policy is concerned with the information architecture requirement that such an overview exists and fulfills its navigational and contextual purpose, regardless of specific tool features that might enhance its presentation. The structural standard [[AS-STRUCTURE-KB-PART_ID_PLACEHOLDER]] ensures the overview is discoverable and consistently named/placed.
+*   **Focus of this Policy:** This policy is concerned with the information architecture requirement that such an overview exists and fulfills its navigational and contextual purpose, regardless of specific tool features that might enhance its presentation. The structural standard [[AS-STRUCTURE-KB-PART]] ensures the overview is discoverable and consistently named/placed.
 
 ## 4. Importance of Part Overviews
 
@@ -56,8 +56,8 @@ This policy mandates the *existence* and *purpose* of the Part overview content 
 This policy applies to all Knowledge Bases and their constituent "Parts." All individuals involved in KB architecture, content creation, and curation are responsible for ensuring that Part overviews are created and maintained according to this policy and the referenced structural standards.
 
 ## 6. Cross-References
-- [[AS-STRUCTURE-KB-PART_ID_PLACEHOLDER]] - Defines the specific structural and content requirements for Part overviews (e.g., `_overview.md` content).
-- [[AS-STRUCTURE-KB-ROOT_ID_PLACEHOLDER]] - Defines how "Parts" are organized within a KB (as folders or sections in `root.md`).
+- [[AS-STRUCTURE-KB-PART]] - Defines the specific structural and content requirements for Part overviews (e.g., `_overview.md` content).
+- [[AS-STRUCTURE-KB-ROOT]] - Defines how "Parts" are organized within a KB (as folders or sections in `root.md`).
 
 ---
 *This policy (CS-POLICY-PART-OVERVIEW) mandates the use of Part Overviews, generalizing concepts previously associated with tool-specific features like Obsidian's folder notes (formerly U-USAGE-FOLDERS-NOTES-001) into a tool-agnostic architectural requirement.*

--- a/master-knowledge-base/standards/src/CS-POLICY-SCOPE-EXCLUSION.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-SCOPE-EXCLUSION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Content Exclusion Principles"
-related-standards: ["CS-POLICY-SCOPE-INCLUSION_ID_PLACEHOLDER"]
+related-standards: ["CS-POLICY-SCOPE-INCLUSION", "SF-FORMATTING-CITATIONS", "SF-LINKS-INTERNAL-SYNTAX"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -44,13 +44,13 @@ Sensitive Personally Identifiable Information (PII) MUST NOT be included in publ
 ### Rule 2.3: Respect for Intellectual Property (Derived from U-SCOPE-EXCLUDE-001, Rule 1.3)
 Proprietary information, copyrighted material, or other intellectual property from third parties to which the organization does not hold explicit rights or a valid license for use and distribution within the KB MUST NOT be included.
 *   **Guidance:** This includes verbatim copying of large text sections from copyrighted books, articles, or websites; use of unlicensed images, software code, or trade secrets.
-*   **Alternative:** Instead of copying, summarize and cite the original source according to [[U-CITE-001_ID_PLACEHOLDER]].
+*   **Alternative:** Instead of copying, summarize and cite the original source according to [[SF-FORMATTING-CITATIONS]].
 *   **Rationale:** Ensures legal compliance with copyright laws and respects the intellectual property rights of others.
 
 ### Rule 2.4: Avoidance of Unnecessary Redundancy (Derived from U-SCOPE-EXCLUDE-001, Rule 1.4)
 Redundant information that is already well-covered and adequately explained elsewhere within the *same Knowledge Base section or its direct conceptual hierarchy* MUST NOT be included if it does not add significant new value, perspective, or context.
 *   **Guidance:**
-    *   Prefer linking to the authoritative source of the information within the KB using [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]].
+    *   Prefer linking to the authoritative source of the information within the KB using [[SF-LINKS-INTERNAL-SYNTAX]].
     *   This rule does not prohibit summaries or syntheses that draw upon multiple sources to create new insights, but rather discourages simple repetition of existing content.
 *   **Rationale:** Improves maintainability (updates only need to happen in one place), reduces KB clutter, and ensures users are directed to the most current and authoritative information on a topic.
 
@@ -70,9 +70,9 @@ Strict adherence to these content exclusion principles is critical for:
 This policy applies to all individuals involved in planning, creating, contributing, curating, or reviewing content for any Knowledge Base within the repository.
 
 ## 5. Cross-References
-- [[CS-POLICY-SCOPE-INCLUSION_ID_PLACEHOLDER]] - Policy detailing what content SHOULD be included.
-- [[U-CITE-001_ID_PLACEHOLDER]] - Standard for Citing External Sources (relevant for avoiding IP issues).
-- [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] - Standard for Internal Linking Syntax (relevant for avoiding redundancy).
+- [[CS-POLICY-SCOPE-INCLUSION]] - Policy detailing what content SHOULD be included.
+- [[SF-FORMATTING-CITATIONS]] - Standard for Citing External Sources (relevant for avoiding IP issues).
+- [[SF-LINKS-INTERNAL-SYNTAX]] - Standard for Internal Linking Syntax (relevant for avoiding redundancy).
 
 ---
 *This policy (CS-POLICY-SCOPE-EXCLUSION) is based on rules 1.1 through 1.4 previously defined in U-SCOPE-EXCLUDE-001 from COL-CONTENT-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-POLICY-SCOPE-INCLUSION.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-SCOPE-INCLUSION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Content Inclusion Principles"
-related-standards: ["CS-POLICY-SCOPE-EXCLUSION_ID_PLACEHOLDER", "U-CITE-001_ID_PLACEHOLDER"]
+related-standards: ["CS-POLICY-SCOPE-EXCLUSION", "SF-FORMATTING-CITATIONS", "AS-STRUCTURE-MASTER-KB-INDEX"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -32,14 +32,14 @@ This policy outlines the universal principles governing the inclusion of content
 
 ### Rule 2.1: Relevance to KB Scope (Derived from U-SCOPE-INCLUDE-001, Rule 1.1)
 All content included in any Knowledge Base (KB) MUST be directly relevant to the stated scope and purpose of that specific KB.
-*   **Guidance:** The scope and purpose of each KB are typically defined in its `root.md` file and its entry in the `kb-directory.md` (see [[AS-STRUCTURE-MASTER-KB-INDEX_ID_PLACEHOLDER]]). Content that falls outside this defined scope should not be included in that particular KB, though it may be relevant for a different KB.
+*   **Guidance:** The scope and purpose of each KB are typically defined in its `root.md` file and its entry in the `kb-directory.md` (see [[AS-STRUCTURE-MASTER-KB-INDEX]]). Content that falls outside this defined scope should not be included in that particular KB, though it may be relevant for a different KB.
 *   **Rationale:** This ensures that KBs remain focused and do not become diluted with irrelevant information, making it easier for users to find what they need.
 
 ### Rule 2.2: Verifiability and Citability (Derived from U-SCOPE-INCLUDE-001, Rule 1.2)
 Content MUST be verifiable or derived from citable sources for KBs that deal with factual information. For KBs focusing on conceptual or philosophical topics, content should be based on logical reasoning and established schools of thought.
 *   **Guidance:**
     *   Factual claims, data, and significant assertions should be supported by evidence.
-    *   Citations for external sources MUST adhere to [[U-CITE-001_ID_PLACEHOLDER]].
+    *   Citations for external sources MUST adhere to [[SF-FORMATTING-CITATIONS]].
 *   **Rationale:** Requiring verifiability and proper citation builds trust in the KB's content and allows users to explore source material for deeper understanding or validation.
 
 ### Rule 2.3: Focus on Actionable and Evergreen Knowledge (Derived from U-SCOPE-INCLUDE-001, Rule 1.3)
@@ -66,9 +66,9 @@ Upholding these content inclusion principles is vital for:
 This policy applies to all individuals involved in planning, creating, contributing, or curating content for any Knowledge Base within the repository.
 
 ## 5. Cross-References
-- [[CS-POLICY-SCOPE-EXCLUSION_ID_PLACEHOLDER]] - Policy detailing what content MUST NOT be included.
-- [[U-CITE-001_ID_PLACEHOLDER]] - Standard for Citing External Sources.
-- [[AS-STRUCTURE-MASTER-KB-INDEX_ID_PLACEHOLDER]] - For understanding how KB scope is documented.
+- [[CS-POLICY-SCOPE-EXCLUSION]] - Policy detailing what content MUST NOT be included.
+- [[SF-FORMATTING-CITATIONS]] - Standard for Citing External Sources.
+- [[AS-STRUCTURE-MASTER-KB-INDEX]] - For understanding how KB scope is documented.
 
 ---
 *This policy (CS-POLICY-SCOPE-INCLUSION) is based on rules 1.1 through 1.3 previously defined in U-SCOPE-INCLUDE-001 from COL-CONTENT-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-POLICY-TONE-LANGUAGE.md
+++ b/master-knowledge-base/standards/src/CS-POLICY-TONE-LANGUAGE.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Tone and Language Standards"
-related-standards: ["GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER"] # Placeholder for a potential glossary standard
+related-standards: ["GM-GLOSSARY-STANDARDS-TERMS"] # Placeholder for a potential glossary standard
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -41,7 +41,7 @@ The tone of content MUST be objective, academic (where appropriate to the subjec
 *   **Rationale:** An objective tone builds trust and credibility. It ensures that the information is presented factually, allowing users to form their own conclusions.
 
 ### Rule 2.3: Consistent Use of Terminology (Derived from U-TONE-LANG-001, Rule 1.3)
-Terminology specific to a domain or subject MUST be used consistently throughout all related documents. If a term has multiple meanings, the intended meaning MUST be clarified upon its first use within a document, or the term should be linked to its definition in a relevant glossary (e.g., [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]]).
+Terminology specific to a domain or subject MUST be used consistently throughout all related documents. If a term has multiple meanings, the intended meaning MUST be clarified upon its first use within a document, or the term should be linked to its definition in a relevant glossary (e.g., [[GM-GLOSSARY-STANDARDS-TERMS]]).
 *   **Example:** If "Systematic Review" is chosen as the standard term, it should be used consistently instead of interchanging it with "structured review" or "comprehensive literature survey" without clarification.
 *   **Rationale:** Consistent terminology prevents confusion and ensures that all readers share a common understanding of key terms. This is vital for precise communication, especially in technical or specialized fields.
 
@@ -66,7 +66,7 @@ This policy applies to all textual content within all Knowledge Bases, including
 *   Content of `primary-topic`, `scope_application`, and similar metadata fields
 
 ## 4. Cross-References
-- [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]] - For definitions of standard terms used across the knowledge base (if such a glossary exists).
+- [[GM-GLOSSARY-STANDARDS-TERMS]] - For definitions of standard terms used across the knowledge base (if such a glossary exists).
 
 ---
 *This policy (CS-POLICY-TONE-LANGUAGE) is based on rules 1.1 through 1.5 previously defined in U-TONE-LANG-001 from COL-CONTENT-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/CS-TOC-POLICY.md
+++ b/master-knowledge-base/standards/src/CS-TOC-POLICY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Table of Contents Policy" # As per prompt
-related-standards: ["SF-TOC-SYNTAX", "AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER"]
+related-standards: ["SF-TOC-SYNTAX", "AS-STRUCTURE-DOC-CHAPTER"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -31,8 +31,8 @@ This policy defines requirements and recommendations for the inclusion, content,
 ## 2. Core ToC Requirements and Recommendations
 
 ### Rule 2.1: ToC Mandate for "Chapter" Documents
-As mandated by [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] (Rule 1.3), all "Chapter" documents (primary content documents) MUST include a Table of Contents.
-*   **Placement:** The ToC typically follows the introductory abstract, as specified in [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]].
+As mandated by [[AS-STRUCTURE-DOC-CHAPTER]] (Rule 1.3), all "Chapter" documents (primary content documents) MUST include a Table of Contents.
+*   **Placement:** The ToC typically follows the introductory abstract, as specified in [[AS-STRUCTURE-DOC-CHAPTER]].
 *   **Rationale:** Essential for navigating longer content documents and understanding their structure at a glance.
 
 ### Rule 2.2: Content of ToC - Heading Levels
@@ -68,7 +68,7 @@ This policy applies to all documents within the knowledge base, particularly "Ch
 
 ## 5. Cross-References
 - [[SF-TOC-SYNTAX]] - Defines the mandatory Markdown syntax for manually created ToCs (and the target output for automated tools).
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - Mandates the inclusion of a ToC in "Chapter" documents and specifies its typical placement.
+- [[AS-STRUCTURE-DOC-CHAPTER]] - Mandates the inclusion of a ToC in "Chapter" documents and specifies its typical placement.
 
 ---
 *This policy (CS-TOC-POLICY) generalizes previous mandates (like O-USAGE-TOC-MANDATE-001) and tool-specific recommendations (like O-USAGE-TOC-PLUGIN-001) into a tool-agnostic policy framework, emphasizing standard Markdown output for ToCs while recommending automation.*

--- a/master-knowledge-base/standards/src/GM-GUIDE-KB-USAGE.md
+++ b/master-knowledge-base/standards/src/GM-GUIDE-KB-USAGE.md
@@ -253,5 +253,5 @@ Certain document types have specific structural requirements defined by their re
 
 ---
 *This guide is intended to be the primary onboarding document for all users of the Knowledge Base. It replaces and expands upon the original `GUIDE-KB-USAGE-AND-STANDARDS.md`.*
-*Refer to the [[_temp/Refactor Roadmap.md]] for the overall refactoring project context.*
+*Refer to the [[Refactor Roadmap.md]] for the overall refactoring project context.*
 *For a task-oriented view of standards, see [[GM-GUIDE-STANDARDS-BY-TASK]].*

--- a/master-knowledge-base/standards/src/GM-GUIDE-STANDARDS-BY-TASK.md
+++ b/master-knowledge-base/standards/src/GM-GUIDE-STANDARDS-BY-TASK.md
@@ -631,5 +631,5 @@ This document provides a task-oriented view of the Universal Knowledge Base Stan
 ---
 *This document provides a task-based entry point to the standards knowledge base. It is intended to complement the [[GM-GUIDE-KB-USAGE]].*
 *It replaces the older `standards/GUIDE-TASK-BASED.md`.*
-*For the overall refactoring project context, refer to the roadmap.*
+*For the overall refactoring project context, refer to [[Refactor Roadmap.md]].*
 *Note: The `[[CONTRIBUTOR_GUIDE.md]]` tracks key decisions and progress of the refactoring effort.*

--- a/master-knowledge-base/standards/src/GM-MANDATE-KB-USAGE-GUIDE.md
+++ b/master-knowledge-base/standards/src/GM-MANDATE-KB-USAGE-GUIDE.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "KB Usage Guide Mandate"
-related-standards: ["GM-GUIDE-KB-USAGE_ID_PLACEHOLDER", "OM-POLICY-STANDARDS-GOVERNANCE_ID_PLACEHOLDER", "MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER", "GM-TEMPLATES-DIRECTORY_ID_PLACEHOLDER"]
+related-standards: ["GM-GUIDE-KB-USAGE", "OM-POLICY-STANDARDS-GOVERNANCE", "MT-REGISTRY-TAG-GLOSSARY", "AS-STRUCTURE-TEMPLATES-DIRECTORY", "AS-STRUCTURE-MASTER-KB-INDEX"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -31,28 +31,28 @@ This standard mandates the creation, maintenance, and core content requirements 
 ## 2. Core Requirements for the Knowledge Base Usage Guide
 
 ### Rule 2.1: Existence and Identification (Derived from U-ONBOARDING-001, Rule 1.1)
-A dedicated guide document, identified by the `standard_id` [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]], MUST exist and be maintained.
-*   **Location:** This guide MUST reside in a well-known location, typically within the `/master-knowledge-base/standards/src/` directory or a dedicated guides section. (The exact path will be determined by the final location of `GM-GUIDE-KB-USAGE_ID_PLACEHOLDER`).
+A dedicated guide document, identified by the `standard_id` [[GM-GUIDE-KB-USAGE]], MUST exist and be maintained.
+*   **Location:** This guide MUST reside in a well-known location, typically within the `/master-knowledge-base/standards/src/` directory or a dedicated guides section. (The exact path will be determined by the final location of `GM-GUIDE-KB-USAGE`).
 *   **Purpose:** This document serves as the primary onboarding resource and comprehensive usage guide for the entire knowledge base ecosystem, including its standards.
 
 ### Rule 2.2: Core Content - Purpose and Navigation (Derived from U-ONBOARDING-001, Rule 1.2)
-The [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]] document MUST, at a minimum:
+The [[GM-GUIDE-KB-USAGE]] document MUST, at a minimum:
     a.  Clearly explain the overall purpose and value of the knowledge base and its associated standards.
     b.  Provide comprehensive instructions on how to navigate the knowledge base structure, including the use of the master `kb-directory.md`, individual KB `root.md` files, collection documents, and Tables of Contents.
     c.  Explain how to find specific standards, policies, and guidelines.
 *   **Rationale:** Ensures users can effectively find and understand the information they need.
 
 ### Rule 2.3: Core Content - Governance Processes (Derived from U-ONBOARDING-001, Rule 1.3)
-The [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]] document MUST briefly outline the process for:
+The [[GM-GUIDE-KB-USAGE]] document MUST briefly outline the process for:
     a.  Proposing new standards or changes to existing standards.
     b.  Asking for clarifications or interpretations of standards.
-*   **Guidance:** This section should link to the detailed governance policy document (expected to be [[OM-POLICY-STANDARDS-GOVERNANCE_ID_PLACEHOLDER]]) for complete procedures.
+*   **Guidance:** This section should link to the detailed governance policy document (expected to be [[OM-POLICY-STANDARDS-GOVERNANCE]]) for complete procedures.
 *   **Rationale:** Facilitates community involvement and ensures users understand how to participate in the evolution of standards.
 
 ### Rule 2.4: Core Content - Pointers to Key Resources (Derived from U-ONBOARDING-001, Rule 1.4)
-The [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]] document SHOULD include pointers (links) to:
-    a.  The master Tag Glossary (expected to be [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]]).
-    b.  The directory or standard defining available document templates (expected to be [[GM-TEMPLATES-DIRECTORY_ID_PLACEHOLDER]] or similar).
+The [[GM-GUIDE-KB-USAGE]] document SHOULD include pointers (links) to:
+    a.  The master Tag Glossary (expected to be [[MT-REGISTRY-TAG-GLOSSARY]]).
+    b.  The directory or standard defining available document templates (expected to be [[AS-STRUCTURE-TEMPLATES-DIRECTORY]] or similar).
 *   **Rationale:** Helps users leverage essential supporting resources for understanding and creating content.
 
 ## 3. Importance of the Usage Guide
@@ -67,14 +67,14 @@ The mandated Knowledge Base Usage Guide is critical for:
 
 ## 4. Scope of Application
 
-This standard applies to the governance body responsible for the knowledge base ecosystem, mandating the provision and maintenance of the [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]] document.
+This standard applies to the governance body responsible for the knowledge base ecosystem, mandating the provision and maintenance of the [[GM-GUIDE-KB-USAGE]] document.
 
 ## 5. Cross-References
-- [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]] - The actual guide document whose existence and core content are mandated by this standard.
-- [[OM-POLICY-STANDARDS-GOVERNANCE_ID_PLACEHOLDER]] - Detailed governance processes.
-- [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]] - The Tag Glossary.
-- [[GM-TEMPLATES-DIRECTORY_ID_PLACEHOLDER]] - Standard defining the templates directory.
-- [[AS-STRUCTURE-MASTER-KB-INDEX_ID_PLACEHOLDER]] - Relevant for explaining navigation via `kb-directory.md`.
+- [[GM-GUIDE-KB-USAGE]] - The actual guide document whose existence and core content are mandated by this standard.
+- [[OM-POLICY-STANDARDS-GOVERNANCE]] - Detailed governance processes.
+- [[MT-REGISTRY-TAG-GLOSSARY]] - The Tag Glossary.
+- [[AS-STRUCTURE-TEMPLATES-DIRECTORY]] - Standard defining the templates directory.
+- [[AS-STRUCTURE-MASTER-KB-INDEX]] - Relevant for explaining navigation via `kb-directory.md`.
 
 ---
 *This standard (GM-MANDATE-KB-USAGE-GUIDE) is based on rules 1.1 through 1.4 previously defined in U-ONBOARDING-001 from COL-GOVERNANCE-UNIVERSAL.md, rephrasing them as mandates for the existence and content of the guide.*

--- a/master-knowledge-base/standards/src/GM-MANDATE-STANDARDS-GLOSSARY.md
+++ b/master-knowledge-base/standards/src/GM-MANDATE-STANDARDS-GLOSSARY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Standards Terminology Glossary Mandate" # As per prompt
-related-standards: ["GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER"] # Points to the actual glossary
+related-standards: ["GM-GLOSSARY-STANDARDS-TERMS", "CS-POLICY-TONE-LANGUAGE"] # Points to the actual glossary
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,18 +26,18 @@ change_log_url: "./GM-MANDATE-STANDARDS-GLOSSARY-changelog.md" # Placeholder
 
 ## 1. Policy Statement
 
-This standard mandates the creation and maintenance of a dedicated glossary for key terms used *within the standards documents themselves*. This glossary, identified as [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]], is crucial for ensuring precise understanding and consistent interpretation of the terminology used across the entire standards ecosystem.
+This standard mandates the creation and maintenance of a dedicated glossary for key terms used *within the standards documents themselves*. This glossary, identified as [[GM-GLOSSARY-STANDARDS-TERMS]], is crucial for ensuring precise understanding and consistent interpretation of the terminology used across the entire standards ecosystem.
 
 ## 2. Core Requirements for the Standards Terminology Glossary
 
 ### Rule 2.1: Existence, Location, and Identification (Derived from U-GLOSSARY-001, Rule 1.1)
-A dedicated glossary document, identified by the `standard_id` [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]], MUST exist and be actively maintained.
+A dedicated glossary document, identified by the `standard_id` [[GM-GLOSSARY-STANDARDS-TERMS]], MUST exist and be actively maintained.
 *   **Content Focus:** This glossary MUST define key terms, jargon, abbreviations, and specific naming conventions (e.g., "atomic standard," "kebab-case," "schema," "frontmatter") that are used throughout the various standard documents. It is distinct from any KB-specific tag glossaries.
 *   **Location:** This glossary document MUST reside at the path `/master-knowledge-base/standards/src/GM-GLOSSARY-STANDARDS-TERMS.md`. (This path is specified based on the expected outcome of Step 2.3).
 *   **Purpose:** To provide a single source of truth for the definitions of terms essential for understanding the standards themselves.
 
 ### Rule 2.2: Clarity of Definitions (Derived from U-GLOSSARY-001, Rule 1.2)
-All terms included in the [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]] document MUST be clearly, concisely, and unambiguously defined.
+All terms included in the [[GM-GLOSSARY-STANDARDS-TERMS]] document MUST be clearly, concisely, and unambiguously defined.
 *   **Guidance:** Definitions should be easy to understand and should clarify the specific meaning of the term as it applies within the context of the standards. Examples may be included within the glossary to aid understanding.
 *   **Rationale:** Clear definitions are fundamental to the utility of the glossary and prevent misinterpretation of standards.
 
@@ -53,11 +53,11 @@ The mandated Standards Terminology Glossary is important for:
 
 ## 4. Scope of Application
 
-This standard applies to the governance body responsible for the knowledge base ecosystem, mandating the provision and maintenance of the [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]] document. It also implicitly guides authors of standards to refer to and utilize this glossary.
+This standard applies to the governance body responsible for the knowledge base ecosystem, mandating the provision and maintenance of the [[GM-GLOSSARY-STANDARDS-TERMS]] document. It also implicitly guides authors of standards to refer to and utilize this glossary.
 
 ## 5. Cross-References
-- [[GM-GLOSSARY-STANDARDS-TERMS_ID_PLACEHOLDER]] - The actual glossary document whose existence and core content are mandated by this standard.
-- [[CS-POLICY-TONE-LANGUAGE_ID_PLACEHOLDER]] - Which emphasizes consistent use of terminology.
+- [[GM-GLOSSARY-STANDARDS-TERMS]] - The actual glossary document whose existence and core content are mandated by this standard.
+- [[CS-POLICY-TONE-LANGUAGE]] - Which emphasizes consistent use of terminology.
 
 ---
 *This standard (GM-MANDATE-STANDARDS-GLOSSARY) is based on rules 1.1 and 1.2 previously defined in U-GLOSSARY-001 from COL-GOVERNANCE-UNIVERSAL.md, rephrasing them as mandates for the existence and content of the standards terminology glossary.*

--- a/master-knowledge-base/standards/src/MT-TAGGING-STRATEGY-POLICY.md
+++ b/master-knowledge-base/standards/src/MT-TAGGING-STRATEGY-POLICY.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Core Tagging Strategy" # As per prompt
-related-standards: ["MT-TAGS-IMPLEMENTATION_ID_PLACEHOLDER", "MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER", "U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER"]
+related-standards: ["MT-TAGS-IMPLEMENTATION", "MT-REGISTRY-TAG-GLOSSARY", "U-METADATA-FRONTMATTER-RULES-001"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./MT-TAGGING-STRATEGY-POLICY-changelog.md" # Placeholder
 
 ## 1. Policy Statement
 
-This policy defines the core strategy for applying tags to knowledge base documents. It mandates the use of specific tag categories to ensure consistent metadata, enhance content discoverability, support faceted search and filtering, and provide semantic meaning for automated processing. All tags MUST conform to the syntax defined in [[MT-TAGS-IMPLEMENTATION_ID_PLACEHOLDER]] and be defined in the [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]].
+This policy defines the core strategy for applying tags to knowledge base documents. It mandates the use of specific tag categories to ensure consistent metadata, enhance content discoverability, support faceted search and filtering, and provide semantic meaning for automated processing. All tags MUST conform to the syntax defined in [[MT-TAGS-IMPLEMENTATION]] and be defined in the [[MT-REGISTRY-TAG-GLOSSARY]].
 
 ## 2. Mandatory Tag Categories and Usage
 
@@ -40,7 +40,7 @@ Every content document (e.g., standards, guides, detailed concepts, methodologie
 
 ### Rule 2.2: `status/*` Tag (Derived from U-TAG-001, Rule 1.6)
 Every document MUST include exactly ONE `status/*` tag to indicate its current lifecycle stage.
-*   **Guidance:** Valid status values (e.g., `status/draft`, `status/in-review`, `status/approved`, `status/deprecated`) are defined in the [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]].
+*   **Guidance:** Valid status values (e.g., `status/draft`, `status/in-review`, `status/approved`, `status/deprecated`) are defined in the [[MT-REGISTRY-TAG-GLOSSARY]].
 *   **Example:** `status/draft`
 *   **Rationale:** Clearly communicates the maturity and reliability of the document content.
 
@@ -54,13 +54,13 @@ Specific tags MUST be used to identify key structural documents within the knowl
 
 ### Rule 2.4: `content-type/*` Tag (Derived from U-TAG-001, Rule 1.8)
 Every document MUST include at least one `content-type/*` tag that describes its nature or format.
-*   **Guidance:** The controlled vocabulary for the `{type}` part of `content-type/{type}` (e.g., `standard-document`, `policy-document`, `guide-document`) is defined in the `tag-glossary-definition.md` file, referenced as [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]]. This aligns with, but is distinct from, the `info-type` frontmatter key detailed in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]].
+*   **Guidance:** The controlled vocabulary for the `{type}` part of `content-type/{type}` (e.g., `standard-document`, `policy-document`, `guide-document`) is defined in the `tag-glossary-definition.md` file, referenced as [[MT-REGISTRY-TAG-GLOSSARY]]. This aligns with, but is distinct from, the `info-type` frontmatter key detailed in [[U-METADATA-FRONTMATTER-RULES-001]].
 *   **Example:** `content-type/technical-standard`, `content-type/conceptual-explanation`
 *   **Rationale:** Allows users and systems to filter content based on its type, facilitating easier access to specific kinds of information.
 
 ## 3. Conformance to Tag Glossary (Derived from U-TAG-001, Rule 1.9 - part)
 
-All tag values used in any document's frontmatter (across all categories like `topic/*`, `status/*`, `content-type/*`, `criticality/*`, etc.) MUST strictly conform to a tag explicitly defined in the official Tag Glossary document ([[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]]).
+All tag values used in any document's frontmatter (across all categories like `topic/*`, `status/*`, `content-type/*`, `criticality/*`, etc.) MUST strictly conform to a tag explicitly defined in the official Tag Glossary document ([[MT-REGISTRY-TAG-GLOSSARY]]).
 *   **Rationale:** Ensures that the tagging system remains controlled, consistent, and meaningful. Prevents the proliferation of ad-hoc or redundant tags, which would degrade the quality and utility of the metadata. The Tag Glossary is the single source of truth for all approved tags.
 
 ## 4. Rationale for Tagging Strategy
@@ -78,9 +78,9 @@ A robust and consistently applied tagging strategy offers numerous benefits:
 This policy applies to all documents within the knowledge base ecosystem that utilize YAML frontmatter for metadata. All contributors and maintainers of content are responsible for adhering to this tagging strategy.
 
 ## 6. Cross-References
-- [[MT-TAGS-IMPLEMENTATION_ID_PLACEHOLDER]] - Defines the syntax and declaration rules for tags.
-- [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]] - The official glossary of all approved tags, their hierarchies, and definitions.
-- [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]] - Defines the `info-type` key and overall frontmatter structure.
+- [[MT-TAGS-IMPLEMENTATION]] - Defines the syntax and declaration rules for tags.
+- [[MT-REGISTRY-TAG-GLOSSARY]] - The official glossary of all approved tags, their hierarchies, and definitions.
+- [[U-METADATA-FRONTMATTER-RULES-001]] - Defines the `info-type` key and overall frontmatter structure.
 
 ---
 *This policy (MT-TAGGING-STRATEGY-POLICY) is based on rules 1.5, 1.6, 1.7, 1.8, and the conformance aspect of 1.9 previously defined in U-TAG-001 from COL-LINKING-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/MT-TAGS-IMPLEMENTATION.md
+++ b/master-knowledge-base/standards/src/MT-TAGS-IMPLEMENTATION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Tag Syntax and Declaration" # As per prompt
-related-standards: ["MT-TAGGING-STRATEGY-POLICY_ID_PLACEHOLDER", "U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER", "MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER"]
+related-standards: ["MT-TAGGING-STRATEGY-POLICY", "U-METADATA-FRONTMATTER-RULES-001", "MT-REGISTRY-TAG-GLOSSARY"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -31,7 +31,7 @@ This standard defines the mandatory syntax and declaration rules for all tags us
 ### Rule 1.1: Declaration in YAML Frontmatter (Derived from U-TAG-001, Rule 1.1)
 All tags associated with a document MUST be declared within the YAML frontmatter block at the beginning of the document.
 *   **Rationale:** Centralizes metadata, making it easily parsable by automated tools and consistently accessible to authors.
-*   **Reference:** General frontmatter structure is defined in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]].
+*   **Reference:** General frontmatter structure is defined in [[U-METADATA-FRONTMATTER-RULES-001]].
 
 ### Rule 1.2: `tags` Key and Block List Format (Derived from U-TAG-001, Rule 1.2)
 Within the YAML frontmatter, tags MUST be listed under a key named exactly `tags`. The value of this key MUST be a block list of strings (each string being a single tag).
@@ -61,15 +61,15 @@ Tags MAY use forward slashes (`/`) to indicate an internal hierarchy or categori
 ## 2. Tag Glossary Requirement (Derived from U-TAG-001, Rule 1.9 - part)
 
 A dedicated Tag Glossary document MUST exist and be maintained. This glossary serves as the single source of truth for all officially recognized tags.
-*   **Identification:** This glossary is identified by the standard ID [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]].
+*   **Identification:** This glossary is identified by the standard ID [[MT-REGISTRY-TAG-GLOSSARY]].
 *   **Purpose:** The Tag Glossary lists all official tags, defines their intended meaning and scope, and illustrates their correct hierarchy and usage.
-*   **Mandate for Conformance:** All tags used in any document's frontmatter MUST conform to a tag defined in the [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]]. The strategic application of these tags is further defined in [[MT-TAGGING-STRATEGY-POLICY_ID_PLACEHOLDER]].
+*   **Mandate for Conformance:** All tags used in any document's frontmatter MUST conform to a tag defined in the [[MT-REGISTRY-TAG-GLOSSARY]]. The strategic application of these tags is further defined in [[MT-TAGGING-STRATEGY-POLICY]].
 *   **Rationale:** Ensures that tags are used consistently and meaningfully across the entire knowledge base, preventing tag proliferation and ambiguity.
 
 ## 3. Cross-References
-- [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]] - Defines general YAML frontmatter structure and rules.
-- [[MT-TAGGING-STRATEGY-POLICY_ID_PLACEHOLDER]] - Outlines the strategic application of different tag categories.
-- [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]] - The official glossary of all approved tags and their definitions.
+- [[U-METADATA-FRONTMATTER-RULES-001]] - Defines general YAML frontmatter structure and rules.
+- [[MT-TAGGING-STRATEGY-POLICY]] - Outlines the strategic application of different tag categories.
+- [[MT-REGISTRY-TAG-GLOSSARY]] - The official glossary of all approved tags and their definitions.
 
 ---
 *This standard (MT-TAGS-IMPLEMENTATION) is based on rules 1.1, 1.2, 1.3, 1.4, and part of 1.9 previously defined in U-TAG-001 from COL-LINKING-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/OM-POLICY-STANDARDS-DEPRECATION.md
+++ b/master-knowledge-base/standards/src/OM-POLICY-STANDARDS-DEPRECATION.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Standards Deprecation Policy" # As per prompt
-related-standards: ["MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER", "SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER", "OM-VERSIONING-CHANGELOGS_ID_PLACEHOLDER"]
+related-standards: ["MT-REGISTRY-TAG-GLOSSARY", "SF-CALLOUTS-SYNTAX", "OM-VERSIONING-CHANGELOGS", "OM-POLICY-STANDARDS-GOVERNANCE"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -37,15 +37,15 @@ When a standard is superseded by a new standard or is deemed no longer relevant,
 ### Rule 2.2: Update Frontmatter Status (Derived from U-DEPRECATION-001, Rule 1.2)
 The YAML frontmatter of a deprecated standard MUST be updated to reflect its new status. Specifically, its `status/*` tag MUST be changed to `status/deprecated`.
 *   **Guidance:** The `status/archived` tag may be used if the standard is not only deprecated but also moved to a separate archive location and is no longer considered part of the active, albeit deprecated, set of standards. The choice between `status/deprecated` (still in place but not active) and `status/archived` (moved and inactive) should be applied consistently based on the archiving strategy (see Rule 2.4).
-*   **Reference:** The list of valid status tags is maintained in [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]].
-*   **Version Update:** The `version` of the standard should be incremented (typically a MINOR or PATCH update, e.g., from `1.2.0` to `1.3.0` or `1.2.1`) and `date-modified` updated to reflect the deprecation event, as per [[OM-VERSIONING-CHANGELOGS_ID_PLACEHOLDER]].
+*   **Reference:** The list of valid status tags is maintained in [[MT-REGISTRY-TAG-GLOSSARY]].
+*   **Version Update:** The `version` of the standard should be incremented (typically a MINOR or PATCH update, e.g., from `1.2.0` to `1.3.0` or `1.2.1`) and `date-modified` updated to reflect the deprecation event, as per [[OM-VERSIONING-CHANGELOGS]].
 
 ### Rule 2.3: Prominent Deprecation Notice (Derived from U-DEPRECATION-001, Rule 1.3)
 The body of a deprecated standard document MUST be prefaced with a prominent and clear "DEPRECATED" notice. This notice MUST:
     a.  Clearly state that the standard is deprecated.
     b.  State the reason for deprecation (e.g., "superseded by...", "no longer applicable due to technology changes...").
     c.  Link directly to any replacing standard(s) if applicable.
-*   **Example using a standard callout format (syntax defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]]):**
+*   **Example using a standard callout format (syntax defined in [[SF-CALLOUTS-SYNTAX]]):**
     ```markdown
     > [!WARNING] DEPRECATED: This Standard is No Longer Active
     > **Reason for Deprecation:** This standard has been superseded by [[NEW-STANDARD-ID_PLACEHOLDER]].
@@ -78,10 +78,10 @@ A formal deprecation policy is essential for:
 This policy applies to all standard documents within the knowledge base ecosystem that are subject to lifecycle changes, including supersession or obsolescence.
 
 ## 5. Cross-References
-- [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]] - For the `status/deprecated` and `status/archived` tags.
-- [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]] - For the syntax of the deprecation notice callout.
-- [[OM-VERSIONING-CHANGELOGS_ID_PLACEHOLDER]] - For versioning changes related to deprecation.
-- [[OM-POLICY-STANDARDS-GOVERNANCE_ID_PLACEHOLDER]] - As the decision to deprecate a standard is a governance action.
+- [[MT-REGISTRY-TAG-GLOSSARY]] - For the `status/deprecated` and `status/archived` tags.
+- [[SF-CALLOUTS-SYNTAX]] - For the syntax of the deprecation notice callout.
+- [[OM-VERSIONING-CHANGELOGS]] - For versioning changes related to deprecation.
+- [[OM-POLICY-STANDARDS-GOVERNANCE]] - As the decision to deprecate a standard is a governance action.
 
 ---
 *This policy (OM-POLICY-STANDARDS-DEPRECATION) is based on rules 1.1 through 1.4 previously defined in U-DEPRECATION-001 from COL-GOVERNANCE-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/OM-POLICY-STANDARDS-GOVERNANCE.md
+++ b/master-knowledge-base/standards/src/OM-POLICY-STANDARDS-GOVERNANCE.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global policy
 info-type: "policy-document"
 primary-topic: "Standards Governance Process"
-related-standards: ["GM-GUIDE-KB-USAGE_ID_PLACEHOLDER", "MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER"] # Updated placeholders
+related-standards: ["GM-GUIDE-KB-USAGE", "MT-REGISTRY-TAG-GLOSSARY", "OM-VERSIONING-CHANGELOGS", "OM-POLICY-STANDARDS-DEPRECATION"] # Updated placeholders
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -32,7 +32,7 @@ This policy establishes the governance framework for proposing, reviewing, updat
 
 ### Rule 2.1: Documented Proposal and Change Process (Derived from U-GOVERNANCE-001, Rule 1.1)
 A defined and documented process for proposing new standards or initiating changes to existing standards MUST be established and maintained.
-*   **Guidance:** This process should be clearly outlined in a readily accessible location, such as the primary "How to Use These Standards" guide (expected to be [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]]) or a dedicated governance document. The process should specify how proposals are submitted (e.g., issue tracker, formal document submission), what information a proposal must contain, and the initial steps for consideration.
+*   **Guidance:** This process should be clearly outlined in a readily accessible location, such as the primary "How to Use These Standards" guide (expected to be [[GM-GUIDE-KB-USAGE]]) or a dedicated governance document. The process should specify how proposals are submitted (e.g., issue tracker, formal document submission), what information a proposal must contain, and the initial steps for consideration.
 *   **Importance:** A documented process ensures transparency and provides a clear pathway for all stakeholders to contribute to the evolution of standards. It prevents ad-hoc changes and promotes systematic development.
 
 ### Rule 2.2: Mandatory Review Process (Derived from U-GOVERNANCE-001, Rule 1.2)
@@ -43,7 +43,7 @@ All proposed new standards and any proposed substantive changes to existing stan
 ### Rule 2.3: Prompt Updates to Registries and Navigational Aids (Derived from U-GOVERNANCE-001, Rule 1.3)
 Upon the addition, significant modification, or deprecation of any standard, all relevant registries and navigational aids MUST be updated promptly.
 *   **Guidance:** This includes, but is not limited to:
-    *   The Tag Glossary (expected to be [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]]) if tags are added, changed, or deprecated as part of the standard's lifecycle.
+    *   The Tag Glossary (expected to be [[MT-REGISTRY-TAG-GLOSSARY]]) if tags are added, changed, or deprecated as part of the standard's lifecycle.
     *   Any master Table of Contents documents, such as `kb-directory.md` or collection documents (e.g., `COL-ARCH-UNIVERSAL.md` before its deprecation).
     *   Automated indices or search databases.
 *   **Importance:** Keeping registries and navigational aids up-to-date is crucial for maintaining the consistency, discoverability, and usability of the standards ecosystem. Outdated information can lead to confusion and hinder the effective application of standards.
@@ -64,10 +64,10 @@ A formal governance process for standards offers several key benefits:
 This policy applies to all standard documents within the knowledge base ecosystem and to all individuals or groups involved in their creation, maintenance, and management.
 
 ## 5. Cross-References
-- [[GM-GUIDE-KB-USAGE_ID_PLACEHOLDER]] - Expected location for detailed procedures on proposing and updating standards.
-- [[MT-REGISTRY-TAG-GLOSSARY_ID_PLACEHOLDER]] - For definitions of tags used in standards, which must be kept current.
-- [[OM-VERSIONING-CHANGELOGS_ID_PLACEHOLDER]] - Defines how changes to standards are versioned and logged.
-- [[OM-POLICY-STANDARDS-DEPRECATION_ID_PLACEHOLDER]] - Policy for deprecating standards, which is part of the governance lifecycle.
+- [[GM-GUIDE-KB-USAGE]] - Expected location for detailed procedures on proposing and updating standards.
+- [[MT-REGISTRY-TAG-GLOSSARY]] - For definitions of tags used in standards, which must be kept current.
+- [[OM-VERSIONING-CHANGELOGS]] - Defines how changes to standards are versioned and logged.
+- [[OM-POLICY-STANDARDS-DEPRECATION]] - Policy for deprecating standards, which is part of the governance lifecycle.
 
 ---
 *This policy (OM-POLICY-STANDARDS-GOVERNANCE) is based on rules 1.1 through 1.3 previously defined in U-GOVERNANCE-001 from COL-GOVERNANCE-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/OM-VERSIONING-CHANGELOGS.md
+++ b/master-knowledge-base/standards/src/OM-VERSIONING-CHANGELOGS.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Standard File Versioning and Changelogs"
-related-standards: ["U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER"]
+related-standards: ["U-METADATA-FRONTMATTER-RULES-001"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,15 +28,15 @@ This standard defines the mandatory requirements for versioning individual stand
 
 ## 1. Frontmatter Versioning Keys (Derived from U-VERSIONING-001, Rule 1.1)
 
-Each individual standard document (including standard definitions, policies, guides, and schemas) MUST include the following keys in its YAML frontmatter, as defined in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]]:
+Each individual standard document (including standard definitions, policies, guides, and schemas) MUST include the following keys in its YAML frontmatter, as defined in [[U-METADATA-FRONTMATTER-RULES-001]]:
 
 *   **`version`**: Specifies the current version of the standard document.
 *   **`date-created`**: Specifies the date (and time) the standard document was initially created. This value SHOULD NOT change after initial creation.
 *   **`date-modified`**: Specifies the date (and time) the standard document was last significantly modified. This MUST be updated upon every substantive change that also warrants a version increment.
 
 *   **Notes:**
-    *   The format for `date-created` and `date-modified` MUST be full ISO-8601 date-time format (e.g., `YYYY-MM-DDTHH:MM:SSZ`) as per [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]].
-    *   The `version` key value MUST also be enclosed in single quotes in YAML (e.g., `version: '1.0.0'`) as specified in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]].
+    *   The format for `date-created` and `date-modified` MUST be full ISO-8601 date-time format (e.g., `YYYY-MM-DDTHH:MM:SSZ`) as per [[U-METADATA-FRONTMATTER-RULES-001]].
+    *   The `version` key value MUST also be enclosed in single quotes in YAML (e.g., `version: '1.0.0'`) as specified in [[U-METADATA-FRONTMATTER-RULES-001]].
 
 ## 2. Semantic Versioning (Derived from U-VERSIONING-001, Rule 1.2)
 
@@ -65,7 +65,7 @@ The `version` key for all standard documents MUST use Semantic Versioning 2.0.0 
 Each individual standard document MUST maintain a human-readable changelog. This changelog SHOULD be:
 
 *   **Location Option 1 (Preferred for Atomic Standards):** A dedicated section within the standard document itself, typically an H2 or H3 heading titled "Changelog" or "Revision History" near the end of the document.
-*   **Location Option 2 (Alternative):** A separate linked changelog file, referenced by the `change_log_url` frontmatter key as defined in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]]. This is the approach this standard itself will follow (see its `change_log_url` frontmatter).
+*   **Location Option 2 (Alternative):** A separate linked changelog file, referenced by the `change_log_url` frontmatter key as defined in [[U-METADATA-FRONTMATTER-RULES-001]]. This is the approach this standard itself will follow (see its `change_log_url` frontmatter).
 
 The changelog MUST record, at a minimum:
 *   The **version number**.
@@ -94,7 +94,7 @@ The changelog MUST record, at a minimum:
 *   **Dependency Management:** In automated systems or when standards reference each other, versioning is critical for managing dependencies.
 
 ## 5. Cross-References
-- [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]] - Defines the mandatory frontmatter keys (`version`, `date-created`, `date-modified`, `change_log_url`) and their formats.
+- [[U-METADATA-FRONTMATTER-RULES-001]] - Defines the mandatory frontmatter keys (`version`, `date-created`, `date-modified`, `change_log_url`) and their formats.
 
 ---
 *This standard (OM-VERSIONING-CHANGELOGS) is based on rules 1.1 through 1.3 previously defined in U-VERSIONING-001 from COL-GOVERNANCE-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/SF-ACCESSIBILITY-IMAGE-ALT-TEXT.md
+++ b/master-knowledge-base/standards/src/SF-ACCESSIBILITY-IMAGE-ALT-TEXT.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Image Alt Text" # As per prompt
-related-standards: ["CS-POLICY-ACCESSIBILITY_ID_PLACEHOLDER", "SF-SYNTAX-MARKDOWN-IMAGES_ID_PLACEHOLDER"] # Placeholder for image syntax
+related-standards: ["CS-POLICY-ACCESSIBILITY", "SF-SYNTAX-IMAGES"] # Placeholder for image syntax
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -34,7 +34,7 @@ This standard mandates the use of descriptive alternative text (alt text) for al
 All images embedded in content that convey information relevant to understanding the content MUST include descriptive alternative text.
 *   **Syntax:** Alt text is provided using the standard Markdown image syntax: `![Alt text description here](path/to/image.png "Optional Title")`
     *   The "Optional Title" part of the Markdown syntax (hover text) is not a replacement for alt text and should be used sparingly, if at all, as its accessibility support varies. Primary focus MUST be on the alt text.
-*   **Reference:** The specific Markdown syntax for images should align with a general Markdown syntax standard, if available (e.g., [[SF-SYNTAX-MARKDOWN-IMAGES_ID_PLACEHOLDER]]).
+*   **Reference:** The specific Markdown syntax for images should align with a general Markdown syntax standard, if available (e.g., [[SF-SYNTAX-IMAGES]]).
 *   **Rationale:** Alt text provides a textual alternative to visual information, making image content accessible to screen readers and search engines, and providing context if images are disabled or fail to load.
 
 ### Rule 2.2: Concise and Sufficiently Descriptive Alt Text (Derived from U-ACCESSIBILITY-001, Rule 1.2)
@@ -76,8 +76,8 @@ If an image is purely decorative and provides no informational value (e.g., a st
 This standard applies to all images (e.g., PNG, JPG, SVG, GIF) embedded within any Markdown document in the knowledge base.
 
 ## 6. Cross-References
-- [[CS-POLICY-ACCESSIBILITY_ID_PLACEHOLDER]] - The overarching policy on content accessibility.
-- [[SF-SYNTAX-MARKDOWN-IMAGES_ID_PLACEHOLDER]] - (If it exists) Standard defining the precise Markdown syntax for images. If not, refer to a general Markdown syntax guide.
+- [[CS-POLICY-ACCESSIBILITY]] - The overarching policy on content accessibility.
+- [[SF-SYNTAX-IMAGES]] - (If it exists) Standard defining the precise Markdown syntax for images. If not, refer to a general Markdown syntax guide.
 
 ---
 *This standard (SF-ACCESSIBILITY-IMAGE-ALT-TEXT) is based on rules 1.1 and 1.2 previously defined in U-ACCESSIBILITY-001 from COL-LINKING-UNIVERSAL.md.*

--- a/master-knowledge-base/standards/src/SF-CALLOUTS-SYNTAX.md
+++ b/master-knowledge-base/standards/src/SF-CALLOUTS-SYNTAX.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Callout/Admonition Syntax" # As per prompt
-related-standards: ["CS-ADMONITIONS-POLICY_ID_PLACEHOLDER", "SF-SYNTAX-BLOCKQUOTES_ID_PLACEHOLDER", "SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"]
+related-standards: ["CS-ADMONITIONS-POLICY", "SF-SYNTAX-BLOCKQUOTES", "SF-FORMATTING-FILE-HYGIENE"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,7 +28,7 @@ change_log_url: "./SF-CALLOUTS-SYNTAX-changelog.md" # Placeholder
 
 This standard defines a generalized Markdown syntax for creating callout or admonition blocks. These blocks are used to highlight specific types of information, such as notes, warnings, tips, or examples, setting them apart from the main narrative flow. The syntax builds upon the standard Markdown blockquote format.
 
-While this standard defines the *syntax*, the policy governing *when and how to use* specific callout types is defined in [[CS-ADMONITIONS-POLICY_ID_PLACEHOLDER]]. Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements is also important.
+While this standard defines the *syntax*, the policy governing *when and how to use* specific callout types is defined in [[CS-ADMONITIONS-POLICY]]. Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements is also important.
 
 ## 2. Core Callout Syntax Rule
 
@@ -44,7 +44,7 @@ Callout/admonition blocks MUST be constructed as an extension of the standard Ma
     > - provided they are correctly indented within the blockquote.
     ```
 *   **Components:**
-    1.  **Blockquote Marker (`>`):** Each line of the callout block MUST begin with the blockquote marker (`>`) followed by a space, as defined in [[SF-SYNTAX-BLOCKQUOTES_ID_PLACEHOLDER]].
+    1.  **Blockquote Marker (`>`):** Each line of the callout block MUST begin with the blockquote marker (`>`) followed by a space, as defined in [[SF-SYNTAX-BLOCKQUOTES]].
     2.  **Type Specifier (`[!TYPE]`):** The first line of the callout block, immediately after the `> `, MUST contain a type specifier enclosed in square brackets and prefixed with an exclamation mark: `[!TYPE]`.
         *   **`TYPE`**: A keyword indicating the nature of the callout. This keyword MUST be uppercase. See "Recommended `TYPE` Keywords" below.
     3.  **Optional Title:** An optional title for the callout MAY follow the `[!TYPE]` specifier on the same line, separated by a space.
@@ -52,7 +52,7 @@ Callout/admonition blocks MUST be constructed as an extension of the standard Ma
 *   **Blank Lines:** A blank line MUST precede and follow the entire callout block.
 
 ### Rule 2.2: Recommended `TYPE` Keywords
-The following uppercase keywords ARE recommended for the `[!TYPE]` specifier to ensure consistency and semantic meaning. Their specific usage is governed by [[CS-ADMONITIONS-POLICY_ID_PLACEHOLDER]].
+The following uppercase keywords ARE recommended for the `[!TYPE]` specifier to ensure consistency and semantic meaning. Their specific usage is governed by [[CS-ADMONITIONS-POLICY]].
 
 *   **`NOTE`**: For general supplementary information or side comments.
 *   **`IMPORTANT`**: For information that users must not overlook.
@@ -67,7 +67,7 @@ The following uppercase keywords ARE recommended for the `[!TYPE]` specifier to 
 *   **`TODO`**: For highlighting to-do items or pending tasks within the document (primarily for editorial/authoring purposes, may be stripped in final output).
 *   **`IF`**: For conditional text presentation logic (if supported by tooling, this indicates a block whose rendering may depend on certain conditions).
 
-*   **Extensibility:** While these are recommended, specific projects or KBs MAY define additional custom types if necessary, but these MUST be documented in a local supplement to [[CS-ADMONITIONS-POLICY_ID_PLACEHOLDER]]. Over-proliferation of types is discouraged.
+*   **Extensibility:** While these are recommended, specific projects or KBs MAY define additional custom types if necessary, but these MUST be documented in a local supplement to [[CS-ADMONITIONS-POLICY]]. Over-proliferation of types is discouraged.
 
 ## 3. Illustrative Examples
 
@@ -117,9 +117,9 @@ The visual appearance (e.g., color, icon) of callout/admonition blocks is determ
 This standard applies to all Markdown documents within the knowledge base repository where callout or admonition blocks are used to highlight information.
 
 ## 7. Cross-References
-- [[CS-ADMONITIONS-POLICY_ID_PLACEHOLDER]] - Policy on when and how to use specific callout types.
-- [[SF-SYNTAX-BLOCKQUOTES_ID_PLACEHOLDER]] - Defines the base blockquote syntax upon which callouts are built.
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements.
+- [[CS-ADMONITIONS-POLICY]] - Policy on when and how to use specific callout types.
+- [[SF-SYNTAX-BLOCKQUOTES]] - Defines the base blockquote syntax upon which callouts are built.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements.
 
 ---
 *This standard (SF-CALLOUTS-SYNTAX) generalizes the Obsidian callout syntax to provide a tool-agnostic method for declaring admonition blocks in Markdown, building upon standard blockquote syntax.*

--- a/master-knowledge-base/standards/src/SF-CONDITIONAL-SYNTAX-ATTRIBUTES.md
+++ b/master-knowledge-base/standards/src/SF-CONDITIONAL-SYNTAX-ATTRIBUTES.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Conditional Attribute Syntax" # As per prompt
-related-standards: ["SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER", "CS-CONTENT-PROFILING-POLICY_ID_PLACEHOLDER"]
+related-standards: ["SF-CALLOUTS-SYNTAX", "CS-CONTENT-PROFILING-POLICY"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,9 +26,9 @@ change_log_url: "./SF-CONDITIONAL-SYNTAX-ATTRIBUTES-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines the specific syntax for the `condition` string used within `[!IF condition]` callout blocks. The general syntax for callouts, including the `[!IF ...]` type, is defined in [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]]. This document focuses solely on the structure and format of the `condition` part itself. Adherence to this syntax is crucial for consistent parsing and application of content profiling rules.
+This standard defines the specific syntax for the `condition` string used within `[!IF condition]` callout blocks. The general syntax for callouts, including the `[!IF ...]` type, is defined in [[SF-CALLOUTS-SYNTAX]]. This document focuses solely on the structure and format of the `condition` part itself. Adherence to this syntax is crucial for consistent parsing and application of content profiling rules.
 
-The actual list of permissible attributes and their corresponding values for use in conditions is defined and managed by the [[CS-CONTENT-PROFILING-POLICY_ID_PLACEHOLDER]].
+The actual list of permissible attributes and their corresponding values for use in conditions is defined and managed by the [[CS-CONTENT-PROFILING-POLICY]].
 
 ## 2. Core Syntax Rules for Condition Strings
 
@@ -79,7 +79,7 @@ Attribute names and their assigned values MUST NOT contain spaces.
 
 ## 4. Management of Attributes and Values
 
-The list of approved profiling attributes (e.g., `audience`, `platform`) and their permissible values (e.g., `expert`, `novice` for `audience`) is defined and managed by the [[CS-CONTENT-PROFILING-POLICY_ID_PLACEHOLDER]]. This standard only defines the syntax for how these attribute-value pairs are expressed within a condition string.
+The list of approved profiling attributes (e.g., `audience`, `platform`) and their permissible values (e.g., `expert`, `novice` for `audience`) is defined and managed by the [[CS-CONTENT-PROFILING-POLICY]]. This standard only defines the syntax for how these attribute-value pairs are expressed within a condition string.
 
 ## 5. Importance of Consistent Condition Syntax
 
@@ -92,8 +92,8 @@ The list of approved profiling attributes (e.g., `audience`, `platform`) and the
 This standard applies to the condition string within all `[!IF condition]` callout blocks used in Markdown documents across the knowledge base.
 
 ## 7. Cross-References
-- [[SF-CALLOUTS-SYNTAX_ID_PLACEHOLDER]] - Defines the general syntax for callout blocks, including the `[!IF ...]` type.
-- [[CS-CONTENT-PROFILING-POLICY_ID_PLACEHOLDER]] - Defines the approved list of profiling attributes and their values, and the overall policy for content profiling.
+- [[SF-CALLOUTS-SYNTAX]] - Defines the general syntax for callout blocks, including the `[!IF ...]` type.
+- [[CS-CONTENT-PROFILING-POLICY]] - Defines the approved list of profiling attributes and their values, and the overall policy for content profiling.
 
 ---
 *This standard (SF-CONDITIONAL-SYNTAX-ATTRIBUTES) is based on rules 1.2 and 1.3 previously defined in M-CONDITIONAL-TEXT-SYNTAX-001.*

--- a/master-knowledge-base/standards/src/SF-CONVENTIONS-NAMING.md
+++ b/master-knowledge-base/standards/src/SF-CONVENTIONS-NAMING.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "File and Folder Naming Conventions"
-related-standards: ["U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER"] # Because standard_id format is defined there
+related-standards: ["U-METADATA-FRONTMATTER-RULES-001", "SF-LINKS-INTERNAL-SYNTAX"] # Because standard_id format is defined there
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -52,7 +52,7 @@ This rule defines the primary naming convention for atomic standard definition, 
 *   **Example:**
     *   `standard_id: SF-CONVENTIONS-NAMING` results in filename: `SF-CONVENTIONS-NAMING.md`
     *   `standard_id: AS-STRUCTURE-KB-ROOT` results in filename: `AS-STRUCTURE-KB-ROOT.md`
-*   **Notes:** This convention supersedes and refines the previous Rule 1.2 from U-FORMAT-NAMING-001 for these specific types of documents. The structure of the `standard_id` itself (and thus the filename) is further detailed in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]].
+*   **Notes:** This convention supersedes and refines the previous Rule 1.2 from U-FORMAT-NAMING-001 for these specific types of documents. The structure of the `standard_id` itself (and thus the filename) is further detailed in [[U-METADATA-FRONTMATTER-RULES-001]].
 
 ### Rule 3.2: General Content Files (Non-Standard Definitions) (Derived from U-FORMAT-NAMING-001, Rule 1.3)
 For general content files (e.g., chapters within a KB part, supplementary documents not defining a formal standard), filenames (excluding the `.md` extension) MUST be descriptive and in **all lowercase kebab-case**.
@@ -84,8 +84,8 @@ Certain filenames are reserved for specific structural purposes and MUST be used
 *   **Notes:** Adherence to these reserved names is crucial for architectural consistency and proper functioning of automated tools. Refer to specific standards defining these files for their exact locations and purposes.
 
 ## 4. Cross-References
-- [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]] - Defines the structure of `standard_id`, which is integral to standard document naming.
-- [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] - Relevant for how names might be used in links.
+- [[U-METADATA-FRONTMATTER-RULES-001]] - Defines the structure of `standard_id`, which is integral to standard document naming.
+- [[SF-LINKS-INTERNAL-SYNTAX]] - Relevant for how names might be used in links.
 
 ---
 *This standard (SF-CONVENTIONS-NAMING) is based on rules 1.1 through 1.8 previously defined in U-FORMAT-NAMING-001 from COL-ARCH-UNIVERSAL.md, with Rule 1.2 significantly refined by the new atomic standard document naming convention (Rule 3.1 here).*

--- a/master-knowledge-base/standards/src/SF-FORMATTING-CITATIONS.md
+++ b/master-knowledge-base/standards/src/SF-FORMATTING-CITATIONS.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Citation of External Sources" # As per prompt
-related-standards: ["SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER"] # For linking syntax in references (though these are external)
+related-standards: ["SF-LINKS-INTERNAL-SYNTAX"] # For linking syntax in references (though these are external)
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -65,7 +65,7 @@ A dedicated section titled "References," formatted as an H2 heading, MUST be inc
 
 When citing online sources, the following specific guidelines apply within the APA 7th Edition framework:
 *   **Hyperlinks:** If the source is publicly available online, a direct and stable hyperlink (URL or DOI) MUST be included in the "References" list entry.
-    *   **Syntax for links:** Standard Markdown link syntax can be used within the reference entry if desired for active links, e.g., `[https://doi.org/xxxx/xxxx](https://doi.org/xxxx/xxxx)` or simply the URL/DOI text which might be auto-linked by renderers. Adherence to [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] is for internal links, but general good practice for link clarity applies.
+    *   **Syntax for links:** Standard Markdown link syntax can be used within the reference entry if desired for active links, e.g., `[https://doi.org/xxxx/xxxx](https://doi.org/xxxx/xxxx)` or simply the URL/DOI text which might be auto-linked by renderers. Adherence to [[SF-LINKS-INTERNAL-SYNTAX]] is for internal links, but general good practice for link clarity applies.
 *   **Retrieval Dates:** According to APA 7th Edition, retrieval dates are generally NOT required for most online sources if the content is stable (e.g., journal articles with DOIs, final versions of web pages). However, a retrieval date MAY be included if the source material is expected to change over time and there is no archive URL (e.g., a frequently updated webpage that is not a formal publication).
     *   **Example (with retrieval date, if necessary):** Author, A. A. (Year, Month Day). *Title of work*. Site Name. Retrieved Month Day, Year, from https://xxxx
 *   **Rationale:** Facilitates direct access to online sources and addresses the dynamic nature of web content.
@@ -83,7 +83,7 @@ When citing online sources, the following specific guidelines apply within the A
 This standard applies to all documents within any Knowledge Base that incorporate information from external sources, whether through direct quotation, paraphrase, data presentation, or summarization.
 
 ## 9. Cross-References
-- [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] - For general Markdown link syntax (though external links are primarily governed by APA 7th style for the URL/DOI presentation itself).
+- [[SF-LINKS-INTERNAL-SYNTAX]] - For general Markdown link syntax (though external links are primarily governed by APA 7th style for the URL/DOI presentation itself).
 - Official APA 7th Edition Style and Grammar Guidelines (External Resource).
 
 ---

--- a/master-knowledge-base/standards/src/SF-FORMATTING-FILE-HYGIENE.md
+++ b/master-knowledge-base/standards/src/SF-FORMATTING-FILE-HYGIENE.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "File Hygiene and Line Endings" # As per prompt
-related-standards: ["U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER"]
+related-standards: ["U-METADATA-FRONTMATTER-RULES-001"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -30,10 +30,10 @@ This standard defines mandatory file hygiene and formatting rules for all text-b
 
 ## 2. Core File Hygiene Rules
 
-### Rule 2.1: UTF-8 Encoding (Consistent with [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]])
+### Rule 2.1: UTF-8 Encoding (Consistent with [[U-METADATA-FRONTMATTER-RULES-001]])
 All text-based files (e.g., `.md`, `.yaml`, `.json`, `.py`) MUST use **UTF-8 (Unicode Transformation Format—8-bit) encoding**.
 *   **Byte Order Mark (BOM):** A Byte Order Mark (BOM) MUST NOT be used at the beginning of files.
-*   **Rationale:** UTF-8 is a universal character encoding standard that supports a wide range of characters and symbols, ensuring broad compatibility. Avoiding BOM prevents potential issues with some tools and parsers, particularly in Unix-like environments. This rule aligns with the frontmatter encoding specified in [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]].
+*   **Rationale:** UTF-8 is a universal character encoding standard that supports a wide range of characters and symbols, ensuring broad compatibility. Avoiding BOM prevents potential issues with some tools and parsers, particularly in Unix-like environments. This rule aligns with the frontmatter encoding specified in [[U-METADATA-FRONTMATTER-RULES-001]].
 
 ### Rule 2.2: Line Feed (LF) Line Endings (Derived from U-FILEHYGIENE-001, Rule 1.1)
 All text-based files MUST use **Line Feed (LF) line endings (Unix-style)**.
@@ -76,7 +76,7 @@ Binary files (e.g., images, PDFs) are exempt from these specific rules (though t
 It is highly recommended to configure text editors and Integrated Development Environments (IDEs) to automatically enforce these file hygiene rules (e.g., by setting default line endings to LF, removing trailing whitespace on save, ensuring a final newline). Project-level configuration files like `.editorconfig` can also be used to help standardize these settings across different editors. Automated linters or pre-commit hooks may also be employed to check for and enforce compliance.
 
 ## 6. Cross-References
-- [[U-METADATA-FRONTMATTER-RULES-001_ID_PLACEHOLDER]] - For specific encoding rules related to YAML frontmatter.
+- [[U-METADATA-FRONTMATTER-RULES-001]] - For specific encoding rules related to YAML frontmatter.
 
 ---
 *This standard (SF-FORMATTING-FILE-HYGIENE) is based on rules 1.1 through 1.3 previously defined in U-FILEHYGIENE-001 from COL-GOVERNANCE-UNIVERSAL.md, and incorporates a general UTF-8 encoding rule.*

--- a/master-knowledge-base/standards/src/SF-FORMATTING-MARKDOWN-GENERAL.md
+++ b/master-knowledge-base/standards/src/SF-FORMATTING-MARKDOWN-GENERAL.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "General Markdown Formatting" # As per prompt
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"]
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./SF-FORMATTING-MARKDOWN-GENERAL-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines general Markdown formatting conventions for paragraphs, line breaks, horizontal rules, and the use of blank lines. Adherence to these conventions is important for ensuring the readability, consistency, and correct parsing of Markdown documents across the knowledge base. These rules complement the file-level hygiene rules defined in [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]].
+This standard defines general Markdown formatting conventions for paragraphs, line breaks, horizontal rules, and the use of blank lines. Adherence to these conventions is important for ensuring the readability, consistency, and correct parsing of Markdown documents across the knowledge base. These rules complement the file-level hygiene rules defined in [[SF-FORMATTING-FILE-HYGIENE]].
 
 ## 2. Core General Formatting Rules
 
@@ -77,7 +77,7 @@ Horizontal rules are used to create a thematic break between sections of content
 *   **Consistency:** For consistency across the knowledge base, **three or more hyphens (`---`) ARE THE PREFERRED STYLE.**
 *   **Spacing:**
     *   The characters forming the rule MAY be separated by spaces.
-    *   A blank line MUST precede and follow a horizontal rule, as per [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]].
+    *   A blank line MUST precede and follow a horizontal rule, as per [[SF-FORMATTING-FILE-HYGIENE]].
 *   **Example (Preferred):**
     ```markdown
     Some content above.
@@ -114,7 +114,7 @@ The use of more than one consecutive blank line to separate content elements (e.
 This standard applies to all Markdown documents within the knowledge base repository.
 
 ## 5. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For file-level hygiene rules including blank lines around block elements and EOF characters.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For file-level hygiene rules including blank lines around block elements and EOF characters.
 
 ---
 *This standard (SF-FORMATTING-MARKDOWN-GENERAL) is based on common Markdown conventions for paragraphs, line breaks, horizontal rules, and blank line usage.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-BLOCKQUOTES.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-BLOCKQUOTES.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Blockquote Syntax" # As per prompt
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # For blank line rules
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"] # For blank line rules
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./SF-SYNTAX-BLOCKQUOTES-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines the mandatory Markdown syntax for creating blockquotes within all knowledge base documents. Consistent use of blockquote syntax is important for visually distinguishing quoted text, ensuring correct rendering, and maintaining readability. Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements is also critical.
+This standard defines the mandatory Markdown syntax for creating blockquotes within all knowledge base documents. Consistent use of blockquote syntax is important for visually distinguishing quoted text, ensuring correct rendering, and maintaining readability. Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements is also critical.
 
 ## 2. Core Blockquote Syntax Rules
 
@@ -72,7 +72,7 @@ A single blank line MUST precede and a single blank line MUST follow every block
 
     This is a paragraph after the blockquote.
     ```
-*   **Rationale:** Ensures correct parsing and rendering of the blockquote as a distinct block element, separating it visually and structurally from surrounding content. This aligns with general file hygiene rules for block elements (see [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]]).
+*   **Rationale:** Ensures correct parsing and rendering of the blockquote as a distinct block element, separating it visually and structurally from surrounding content. This aligns with general file hygiene rules for block elements (see [[SF-FORMATTING-FILE-HYGIENE]]).
 
 ## 3. Importance of Correct Blockquote Syntax
 
@@ -86,7 +86,7 @@ A single blank line MUST precede and a single blank line MUST follow every block
 This standard applies to all Markdown documents within the knowledge base repository where text is quoted from external sources or other documents.
 
 ## 5. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines and file formatting that apply to block elements.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines and file formatting that apply to block elements.
 
 ---
 *This standard (SF-SYNTAX-BLOCKQUOTES) is based on rules 1.1 through 1.3 previously defined in M-SYNTAX-BLOCKQUOTE-001 from COL-SYNTAX-MARKDOWN.md.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-CODE.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-CODE.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Code Syntax" # As per assumed keyword
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # For blank line rules around blocks
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"] # For blank line rules around blocks
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./SF-SYNTAX-CODE-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines the mandatory Markdown syntax for representing inline code snippets and extended code blocks within all knowledge base documents. Consistent and correct code syntax is essential for readability, accuracy, and proper rendering, including syntax highlighting where applicable. Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements is also important for code blocks.
+This standard defines the mandatory Markdown syntax for representing inline code snippets and extended code blocks within all knowledge base documents. Consistent and correct code syntax is essential for readability, accuracy, and proper rendering, including syntax highlighting where applicable. Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements is also important for code blocks.
 
 ## 2. Core Code Syntax Rules
 
@@ -59,7 +59,7 @@ Fenced code blocks MUST be used for multi-line code examples or longer code snip
         ```
         ````
     *   **Common Language Identifiers:** `python`, `javascript`, `java`, `csharp`, `bash`, `yaml`, `json`, `html`, `css`, `sql`, `markdown`, `text` (for plain text).
-*   **Blank Lines:** A blank line SHOULD precede and follow the fenced code block for readability and to ensure correct parsing, as per [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]].
+*   **Blank Lines:** A blank line SHOULD precede and follow the fenced code block for readability and to ensure correct parsing, as per [[SF-FORMATTING-FILE-HYGIENE]].
 *   **Rationale:** Fenced code blocks are the most common and robust method for displaying code, offering clear delimitation and support for language-specific syntax highlighting, which significantly improves readability and comprehension.
 
 ### Rule 2.3: Indented Code Blocks (Alternative, Less Preferred)
@@ -92,7 +92,7 @@ Indented code blocks, created by indenting each line of the code block by four (
 This standard applies to all Markdown documents within the knowledge base repository where inline code or code blocks are used.
 
 ## 5. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements.
 
 ---
 *This standard (SF-SYNTAX-CODE) is based on common Markdown conventions for inline code and code blocks, emphasizing the preference for fenced code blocks with language identifiers.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-DEFINITION-LISTS.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-DEFINITION-LISTS.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Definition List Syntax" # As per prompt
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # For blank line rules
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"] # For blank line rules
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,7 +28,7 @@ change_log_url: "./SF-SYNTAX-DEFINITION-LISTS-changelog.md" # Placeholder
 
 This standard defines the recommended syntax for creating definition lists within Markdown documents. Definition lists are used to present a series of terms, each followed by one or more definitions or descriptions. While not part of the core CommonMark specification, definition list syntax is a common extension supported by many Markdown processors.
 
-Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements is also important for definition lists.
+Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements is also important for definition lists.
 
 ## 2. Core Definition List Syntax (Common Extension)
 
@@ -115,7 +115,7 @@ Parser
 This standard applies to all Markdown documents within the knowledge base repository where definition lists are used to present terms and their corresponding definitions or descriptions.
 
 ## 7. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements.
 
 ---
 *This standard (SF-SYNTAX-DEFINITION-LISTS) is based on common Markdown extension syntax for definition lists.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-DIAGRAMS-MERMAID.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-DIAGRAMS-MERMAID.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Mermaid Diagram Syntax in Markdown" # As per prompt
-related-standards: ["SF-SYNTAX-CODE_ID_PLACEHOLDER", "SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # Uses code block syntax
+related-standards: ["SF-SYNTAX-CODE", "SF-FORMATTING-FILE-HYGIENE"] # Uses code block syntax
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,7 +28,7 @@ change_log_url: "./SF-SYNTAX-DIAGRAMS-MERMAID-changelog.md" # Placeholder
 
 This standard defines the mandatory syntax for embedding Mermaid diagrams within Markdown documents. Mermaid is a JavaScript-based diagramming and charting tool that uses a Markdown-inspired text definition to create and modify diagrams dynamically. Utilizing Mermaid allows for diagrams to be version-controlled and treated as code.
 
-This standard specifies how to embed Mermaid definitions within Markdown. The full syntax for Mermaid diagram types themselves is defined by the official Mermaid documentation. Adherence to [[SF-SYNTAX-CODE_ID_PLACEHOLDER]] for fenced code blocks and [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements is also important.
+This standard specifies how to embed Mermaid definitions within Markdown. The full syntax for Mermaid diagram types themselves is defined by the official Mermaid documentation. Adherence to [[SF-SYNTAX-CODE]] for fenced code blocks and [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements is also important.
 
 ## 2. Core Mermaid Diagram Embedding Rule
 
@@ -45,7 +45,7 @@ Mermaid diagrams MUST be embedded within a standard Markdown fenced code block, 
     ```
     ````
 *   **Content:** The content within this fenced code block MUST be valid Mermaid diagram syntax.
-*   **Blank Lines:** A blank line MUST precede and follow the ` ```mermaid ` block to ensure correct parsing and rendering, as per [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]].
+*   **Blank Lines:** A blank line MUST precede and follow the ` ```mermaid ` block to ensure correct parsing and rendering, as per [[SF-FORMATTING-FILE-HYGIENE]].
 *   **Rationale:** Using a fenced code block with a specific language identifier (`mermaid`) is the common and recognized method for embedding Mermaid diagrams, allowing Markdown processors and rendering tools to identify and process the diagram definition correctly.
 
 ## 3. Mermaid Diagram Content
@@ -108,8 +108,8 @@ This demonstrates a basic flowchart with a start, a process step, a decision poi
 This standard applies to all Markdown documents within the knowledge base repository where diagrams are embedded using the Mermaid syntax.
 
 ## 8. Cross-References
-- [[SF-SYNTAX-CODE_ID_PLACEHOLDER]] - For the general rules regarding fenced code blocks.
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements.
+- [[SF-SYNTAX-CODE]] - For the general rules regarding fenced code blocks.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements.
 - [Official Mermaid Documentation](https://mermaid.js.org/intro/syntax-reference.html) (External Resource) - For the full syntax of Mermaid diagram types.
 
 ---

--- a/master-knowledge-base/standards/src/SF-SYNTAX-FOOTNOTES.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-FOOTNOTES.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Footnote Syntax" # As per prompt
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # For blank line rules
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"] # For blank line rules
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,7 +28,7 @@ change_log_url: "./SF-SYNTAX-FOOTNOTES-changelog.md" # Placeholder
 
 This standard defines the recommended syntax for creating footnotes within Markdown documents. Footnotes are used to provide supplementary information, explanations, or citations without disrupting the main flow of the text. While not part of the core CommonMark specification, footnote syntax is a common extension supported by many Markdown processors.
 
-Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements (like the footnote definition block) is also important.
+Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements (like the footnote definition block) is also important.
 
 ## 2. Core Footnote Syntax (Common Extension)
 
@@ -119,7 +119,7 @@ Here's a concept that requires some clarification.<sup>3</sup> We also need to c
 This standard applies to all Markdown documents within the knowledge base repository where footnotes are used for supplementary information, explanations, or citations.
 
 ## 7. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements like footnote definition blocks.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements like footnote definition blocks.
 
 ---
 *This standard (SF-SYNTAX-FOOTNOTES) is based on common Markdown extension syntax for footnotes.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-HEADINGS.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-HEADINGS.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Heading Syntax" # As per prompt
-related-standards: ["AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER", "CS-POLICY-DOC-CHAPTER-CONTENT_ID_PLACEHOLDER", "SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"]
+related-standards: ["AS-STRUCTURE-DOC-CHAPTER", "CS-POLICY-DOC-CHAPTER-CONTENT", "SF-FORMATTING-FILE-HYGIENE"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,7 +28,7 @@ change_log_url: "./SF-SYNTAX-HEADINGS-changelog.md" # Placeholder
 
 This standard defines the mandatory Markdown syntax for creating headings (H1 through H6) in all knowledge base documents. Consistent and correct heading syntax is fundamental for document structure, readability, accessibility, and reliable automated processing (such as Table of Contents generation).
 
-While this document specifies the *syntax* for headings, the *semantic application* of these headings (e.g., using a single H1 for the document title, not skipping levels, how H2s structure a chapter) is governed by content structure standards like [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] and policies like [[CS-POLICY-DOC-CHAPTER-CONTENT_ID_PLACEHOLDER]]. Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around headings is also critical.
+While this document specifies the *syntax*, the *semantic application* of these headings (e.g., using a single H1 for the document title, not skipping levels, how H2s structure a chapter) is governed by content structure standards like [[AS-STRUCTURE-DOC-CHAPTER]] and policies like [[CS-POLICY-DOC-CHAPTER-CONTENT]]. Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around headings is also critical.
 
 ## 2. Core Heading Syntax Rules
 
@@ -64,7 +64,7 @@ A single blank line MUST precede and a single blank line MUST follow every headi
     ```
 *   **Exceptions:**
     *   A heading at the very beginning of a document (typically the H1 title) does not require a blank line before it (as it's preceded by the YAML frontmatter).
-    *   A heading at the very end of a document does not require a blank line after it (though the file should still end with a single newline character as per [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]]).
+    *   A heading at the very end of a document does not require a blank line after it (though the file should still end with a single newline character as per [[SF-FORMATTING-FILE-HYGIENE]]).
 *   **Rationale:** Improves readability of the raw Markdown source and prevents potential parsing issues with some Markdown processors, ensuring headings are correctly rendered as distinct blocks.
 
 ## 3. Semantic Application of Headings (Context from M-SYNTAX-HEADINGS-001, Rules 1.3 & 1.4)
@@ -74,13 +74,13 @@ While this document focuses on syntax, the following semantic rules are critical
 ### Rule 3.1: Single H1 Heading for Document Title
 Each document MUST begin with a single H1 heading, which serves as the document's main title. No other H1 headings should appear in the document.
 *   **Syntax Example:** `# Document Title Here`
-*   **Governance:** This rule's application and how it forms the basis of chapter structure is detailed in [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]].
+*   **Governance:** This rule's application and how it forms the basis of chapter structure is detailed in [[AS-STRUCTURE-DOC-CHAPTER]].
 
 ### Rule 3.2: No Skipping Heading Levels
 Heading levels MUST be used hierarchically without skipping levels. For example, an H2 heading can be followed by an H3, but not directly by an H4.
 *   **Correct Sequence Example:** H1 -> H2 -> H3 -> H2 -> H3
 *   **Incorrect Sequence Example:** H1 -> H3 (skips H2)
-*   **Governance:** The policy ensuring correct hierarchical heading usage for content organization is detailed in [[CS-POLICY-DOC-CHAPTER-CONTENT_ID_PLACEHOLDER]].
+*   **Governance:** The policy ensuring correct hierarchical heading usage for content organization is detailed in [[CS-POLICY-DOC-CHAPTER-CONTENT]].
 
 ## 4. Importance of Correct Heading Syntax
 
@@ -94,9 +94,9 @@ Heading levels MUST be used hierarchically without skipping levels. For example,
 This standard applies to all Markdown documents within the knowledge base repository.
 
 ## 6. Cross-References
-- [[AS-STRUCTURE-DOC-CHAPTER_ID_PLACEHOLDER]] - Defines the overall internal structure for Chapter documents, including the use of the H1 as the title.
-- [[CS-POLICY-DOC-CHAPTER-CONTENT_ID_PLACEHOLDER]] - Governs the semantic use of headings (H2-H6) for content organization within Chapters.
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines and EOF characters that interact with heading formatting.
+- [[AS-STRUCTURE-DOC-CHAPTER]] - Defines the overall internal structure for Chapter documents, including the use of the H1 as the title.
+- [[CS-POLICY-DOC-CHAPTER-CONTENT]] - Governs the semantic use of headings (H2-H6) for content organization within Chapters.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines and EOF characters that interact with heading formatting.
 
 ---
 *This standard (SF-SYNTAX-HEADINGS) is based on rules 1.1, 1.2, and 1.5 previously defined in M-SYNTAX-HEADINGS-001 from COL-SYNTAX-MARKDOWN.md. Rules 1.3 and 1.4 regarding semantic application are noted and deferred to content structure standards.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-IMAGES.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-IMAGES.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Image Syntax" # As per prompt
-related-standards: ["SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER", "AS-STRUCTURE-ASSET-ORGANIZATION_ID_PLACEHOLDER"]
+related-standards: ["SF-ACCESSIBILITY-IMAGE-ALT-TEXT", "AS-STRUCTURE-ASSET-ORGANIZATION"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -45,7 +45,7 @@ An image link is prefixed with an exclamation mark (`!`).
 Alternative text (alt text) is enclosed in square brackets (`[]`).
 *   **Requirement:** Alt text is **mandatory** for all informational images.
 *   **Purpose:** Provides a textual description of the image for users who cannot see it (e.g., users with screen readers, or if the image fails to load). It is critical for accessibility.
-*   **Detailed Guidelines:** For comprehensive rules on how to write effective and descriptive alt text, refer to [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]].
+*   **Detailed Guidelines:** For comprehensive rules on how to write effective and descriptive alt text, refer to [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]].
 *   **Example:** `![Architectural diagram showing user authentication flow]`
 *   **Rationale:** Essential for accessibility (WCAG compliance) and provides context when images are unavailable.
 
@@ -54,7 +54,7 @@ The URL or path to the image file is enclosed in parentheses (`()`).
 *   **Content:** This can be:
     *   A relative path to an image file stored within the knowledge base repository (preferred for internal assets).
     *   An absolute URL to an image hosted externally.
-*   **Asset Organization:** For images stored internally, the path SHOULD adhere to the conventions defined in [[AS-STRUCTURE-ASSET-ORGANIZATION_ID_PLACEHOLDER]] (e.g., pointing to a file within the `assets/images/` directory of the respective KB).
+*   **Asset Organization:** For images stored internally, the path SHOULD adhere to the conventions defined in [[AS-STRUCTURE-ASSET-ORGANIZATION]] (e.g., pointing to a file within the `assets/images/` directory of the respective KB).
 *   **Example (Relative Path):** `(./assets/images/my-diagram.png)`
 *   **Example (Absolute URL):** `(https://example.com/path/to/image.jpg)`
 *   **Rationale:** Specifies the source from which the browser or Markdown renderer should fetch and display the image.
@@ -84,7 +84,7 @@ An optional title for the image can be included in quotes after the URL/path, se
 ```
 
 ### Example 3.4: Purely Decorative Image (Use Sparingly)
-As per [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]], if an image is purely decorative and adds no informational value:
+As per [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]], if an image is purely decorative and adds no informational value:
 ```markdown
 ![](./assets/images/decorative-border.png) 
 ```
@@ -103,8 +103,8 @@ As per [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]], if an image is purely
 This standard applies to all Markdown documents within the knowledge base repository where images are embedded.
 
 ## 6. Cross-References
-- [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT_ID_PLACEHOLDER]] - For detailed guidelines on writing effective alternative text.
-- [[AS-STRUCTURE-ASSET-ORGANIZATION_ID_PLACEHOLDER]] - For rules on storing and organizing image files and other assets.
+- [[SF-ACCESSIBILITY-IMAGE-ALT-TEXT]] - For detailed guidelines on writing effective alternative text.
+- [[AS-STRUCTURE-ASSET-ORGANIZATION]] - For rules on storing and organizing image files and other assets.
 
 ---
 *This standard (SF-SYNTAX-IMAGES) is based on common Markdown image syntax conventions and emphasizes integration with accessibility and asset organization standards.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-KEYREF.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-KEYREF.md
@@ -1,0 +1,54 @@
+---
+title: "Standard: Key-Based Referencing Syntax"
+standard_id: "SF-SYNTAX-KEYREF"
+aliases: ["Keyref Syntax", "Key-Based Referencing"]
+tags:
+  - status/draft
+  - content-type/standard-definition
+  - topic/syntax
+  - topic/keyref
+  - primary_domain/SF
+  - sub_domain/SYNTAX
+kb-id: "standards"
+info-type: "standard-definition"
+primary-topic: "Defines the Markdown-compatible syntax for key-based referencing (keyrefs) used for dynamic content insertion."
+related-standards: ["MT-KEYREF-MANAGEMENT"] # Assuming U-KEYREF-MANAGEMENT-001 will become MT-KEYREF-MANAGEMENT
+version: "1.0.0"
+date-created: "2025-05-29T13:24:53Z" # Placeholder
+date-modified: "2025-05-29T13:24:53Z" # Placeholder
+primary_domain: "SF"
+sub_domain: "SYNTAX"
+scope_application: "Applies to all knowledge base documents where key-based referencing is used for content reuse and consistency."
+criticality: "P2-Medium"
+lifecycle_gatekeeper: "Architect-Review"
+impact_areas: ["Content consistency", "Maintainability", "Automation (keyref resolution)", "Authoring efficiency"]
+change_log_url: "./SF-SYNTAX-KEYREF-changelog.md"
+---
+
+# Standard: Key-Based Referencing Syntax (SF-SYNTAX-KEYREF)
+
+## 1. Introduction
+
+This document defines the universal standard for the syntax of key-based referencing (keyref) placeholders within content. These placeholders allow for indirect referencing of values defined centrally, promoting consistency and maintainability.
+
+## 2. Rule/Guideline Statement(s)
+
+| Rule ID | Statement                                                                                                                                                                                             | Notes                                                                                                                                                                                                                            |
+| :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.1     | Keyref placeholders MUST use double curly braces `{{ }}` enclosing the prefix `key.` followed by the key name (e.g., `key.yourKeyName`). Key names are case-sensitive as defined in [[UA-KEYDEFS-GLOBAL]]. The `key.` prefix is mandatory. | This syntax is chosen for its commonality in templating languages and to minimize conflict with standard Markdown or HTML. The `key.` prefix provides a clear namespace.                                                              |
+| 2.2     | Key names within the placeholder SHOULD follow camelCase convention (e.g., `officialCompanyName`) for readability and consistency, though the ultimate source of truth for key names is [[UA-KEYDEFS-GLOBAL]]. | While camelCase is recommended for new key creation, the resolver MUST use the exact case as defined in `[[UA-KEYDEFS-GLOBAL]]`.                                                                                                  |
+| 2.3     | Whitespace within the curly braces, around the key name or `key.` prefix, is NOT PERMITTED.                                                                                                              | Example (Incorrect): `{{ key.yourKeyName }}` or `{{key. yourKeyName}}`. <br> Example (Correct): `{{key.yourKeyName}}`. <br> This ensures simpler parsing logic for the resolver script.                                                   |
+
+## 3. Importance of Keyref Syntax
+
+*   **Consistency:** Ensures all authors use the same syntax for referencing centrally managed values.
+*   **Maintainability:** When a value changes, it only needs to be updated in the central definitions file ([[UA-KEYDEFS-GLOBAL]]), and all keyrefs will reflect the change upon rendering.
+*   **Automation:** A clear and strict syntax allows for reliable automated processing (e.g., by a resolver script) to replace placeholders with their actual values.
+*   **Readability:** The `{{key.name}}` format is generally readable in raw Markdown and clearly indicates a placeholder.
+
+## 4. Cross-References
+- [[MT-KEYREF-MANAGEMENT]] - Defines the policy and process for managing the central key definition file.
+- [[UA-KEYDEFS-GLOBAL]] - The actual file where key-value pairs are stored (this standard will define its structure and rules).
+
+---
+*This standard (SF-SYNTAX-KEYREF) is based on the rules previously defined in U-KEYREF-SYNTAX-001.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-LINKS-GENERAL.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-LINKS-GENERAL.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "General Markdown Link Syntax" # As per prompt
-related-standards: ["SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER", "CS-LINKING-INTERNAL-POLICY_ID_PLACEHOLDER"]
+related-standards: ["SF-LINKS-INTERNAL-SYNTAX", "CS-LINKING-INTERNAL-POLICY", "AS-STRUCTURE-ASSET-ORGANIZATION"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./SF-SYNTAX-LINKS-GENERAL-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines the general Markdown syntax for creating hyperlinks, primarily focusing on external links and internal links using relative paths (e.g., to assets or non-standard documents). It complements [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]], which specifically governs the `[[STANDARD_ID]]` syntax for linking between standard documents. Adherence to these syntactical rules is essential for link integrity, readability, and consistent parsing.
+This standard defines the general Markdown syntax for creating hyperlinks, primarily focusing on external links and internal links using relative paths (e.g., to assets or non-standard documents). It complements [[SF-LINKS-INTERNAL-SYNTAX]], which specifically governs the `[[STANDARD_ID]]` syntax for linking between standard documents. Adherence to these syntactical rules is essential for link integrity, readability, and consistent parsing.
 
 ## 2. Core Link Syntax Rules
 
@@ -54,7 +54,7 @@ Internal links to non-standard documents (e.g., supplementary materials not gove
     ```markdown
     Refer to the [detailed setup guide](./supplementary-docs/detailed-setup.md).
     ```
-*   **Important Distinction for Standard Documents:** For linking *between standard documents* (i.e., documents that have a `standard_id`), the mandatory convention is `[[STANDARD_ID]]` as defined in [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]]. The relative path method described here is NOT for linking standard documents to each other.
+*   **Important Distinction for Standard Documents:** For linking *between standard documents* (i.e., documents that have a `standard_id`), the mandatory convention is `[[STANDARD_ID]]` as defined in [[SF-LINKS-INTERNAL-SYNTAX]]. The relative path method described here is NOT for linking standard documents to each other.
 *   **Rationale:** Relative paths provide a robust way to link to local files within the repository structure, ensuring links remain valid as long as the relative positions of files are maintained.
 
 ### Rule 2.3: Prohibition of Reference-Style Links (Derived from M-SYNTAX-LINKS-001, Rule 1.3)
@@ -75,7 +75,7 @@ To display a raw URL or email address as a clickable link, it MUST be enclosed i
 
 ## 3. Link Display Text (General Guidance)
 
-While [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] provides specific guidance on display text for `[[STANDARD_ID]]` links (Rule 1.5 from M-SYNTAX-LINKS-001 regarding no escaping pipes for `[[STANDARD_ID|Display Text]]` is best suited there), the general principle of descriptive link text applies to all links created using the syntax in this standard:
+While [[SF-LINKS-INTERNAL-SYNTAX]] provides specific guidance on display text for `[[STANDARD_ID]]` links (Rule 1.5 from M-SYNTAX-LINKS-001 regarding no escaping pipes for `[[STANDARD_ID|Display Text]]` is best suited there), the general principle of descriptive link text applies to all links created using the syntax in this standard:
 *   Link display text SHOULD clearly indicate the content or purpose of the link's destination.
 *   Avoid generic link text like "click here" or "more info."
 
@@ -88,13 +88,13 @@ While [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] provides specific guidance on 
 
 ## 5. Scope of Application
 
-This standard applies to all Markdown documents within the knowledge base repository when creating external links or internal links to non-standard documents or assets using relative paths. For linking between standard documents, [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] MUST be followed.
+This standard applies to all Markdown documents within the knowledge base repository when creating external links or internal links to non-standard documents or assets using relative paths. For linking between standard documents, [[SF-LINKS-INTERNAL-SYNTAX]] MUST be followed.
 
 ## 6. Cross-References
-- [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]] - Defines the mandatory `[[STANDARD_ID]]` syntax for linking between standard documents.
-- [[CS-LINKING-INTERNAL-POLICY_ID_PLACEHOLDER]] - Outlines the strategy and best practices for internal linking.
-- [[AS-STRUCTURE-ASSET-ORGANIZATION_ID_PLACEHOLDER]] - For guidance on organizing and linking to assets.
+- [[SF-LINKS-INTERNAL-SYNTAX]] - Defines the mandatory `[[STANDARD_ID]]` syntax for linking between standard documents.
+- [[CS-LINKING-INTERNAL-POLICY]] - Outlines the strategy and best practices for internal linking.
+- [[AS-STRUCTURE-ASSET-ORGANIZATION]] - For guidance on organizing and linking to assets.
 
 ---
-*This standard (SF-SYNTAX-LINKS-GENERAL) is based on rules 1.1 (partially), 1.2, 1.3, and 1.4 previously defined in M-SYNTAX-LINKS-001 from COL-SYNTAX-MARKDOWN.md. It clarifies the use of relative path Markdown links for non-standard documents/assets and defers standard-to-standard linking to [[SF-LINKS-INTERNAL-SYNTAX_ID_PLACEHOLDER]]. Rule 1.5 regarding pipe escaping is primarily relevant to the wikilink/STANDARD_ID syntax.*
+*This standard (SF-SYNTAX-LINKS-GENERAL) is based on rules 1.1 (partially), 1.2, 1.3, and 1.4 previously defined in M-SYNTAX-LINKS-001 from COL-SYNTAX-MARKDOWN.md. It clarifies the use of relative path Markdown links for non-standard documents/assets and defers standard-to-standard linking to [[SF-LINKS-INTERNAL-SYNTAX]]. Rule 1.5 regarding pipe escaping is primarily relevant to the wikilink/STANDARD_ID syntax.*
 ```

--- a/master-knowledge-base/standards/src/SF-SYNTAX-LISTS.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-LISTS.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown List Syntax" # As per prompt
-related-standards: ["SF-SYNTAX-TABLES_ID_PLACEHOLDER", "SF-SYNTAX-CODE-BLOCKS_ID_PLACEHOLDER", "SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"]
+related-standards: ["SF-SYNTAX-TABLES", "SF-SYNTAX-CODE", "SF-FORMATTING-FILE-HYGIENE"]
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./SF-SYNTAX-LISTS-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines the mandatory Markdown syntax for creating ordered (numbered) and unordered (bulleted) lists. Consistent and correct list syntax is essential for document structure, readability, accessibility, and reliable parsing by Markdown processors. Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around list blocks is also critical.
+This standard defines the mandatory Markdown syntax for creating ordered (numbered) and unordered (bulleted) lists. Consistent and correct list syntax is essential for document structure, readability, accessibility, and reliable parsing by Markdown processors. Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around list blocks is also critical.
 
 ## 2. Core List Syntax Rules
 
@@ -82,7 +82,7 @@ A single blank line MUST precede and a single blank line MUST follow every list 
 *   **Rationale:** Ensures correct list parsing and rendering, preventing adjacent paragraphs from being unintentionally absorbed into list items or lists from merging.
 
 ### Rule 2.5: Prohibited Content Directly Inside List Items (Derived from M-SYNTAX-LISTS-001, Rule 1.5)
-Complex block elements such as tables (see [[SF-SYNTAX-TABLES_ID_PLACEHOLDER]]) or fenced code blocks (see [[SF-SYNTAX-CODE-BLOCKS_ID_PLACEHOLDER]]) MUST NOT be placed directly inside list items without proper separation or advanced list continuation syntax.
+Complex block elements such as tables (see [[SF-SYNTAX-TABLES]]) or fenced code blocks (see [[SF-SYNTAX-CODE]]) MUST NOT be placed directly inside list items without proper separation or advanced list continuation syntax.
 *   **Guidance:**
     *   For simple cases, such elements should be placed outside the list, separated by blank lines.
     *   If a table or code block logically belongs *within* a list item's content, it typically requires an additional level of indentation (usually 4 spaces or 1 tab, depending on the parser, beyond the list item's own indentation) and often a blank line between the list item's text and the complex block. However, for maximum compatibility and simplicity, placing them outside the list is preferred. This standard primarily discourages direct, unindented embedding that breaks list flow.
@@ -120,9 +120,9 @@ Paragraph after list.
 This standard applies to all Markdown documents within the knowledge base repository where ordered or unordered lists are used.
 
 ## 6. Cross-References
-- [[SF-SYNTAX-TABLES_ID_PLACEHOLDER]] - For syntax rules related to tables.
-- [[SF-SYNTAX-CODE-BLOCKS_ID_PLACEHOLDER]] - For syntax rules related to code blocks.
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines and file formatting.
+- [[SF-SYNTAX-TABLES]] - For syntax rules related to tables.
+- [[SF-SYNTAX-CODE]] - For syntax rules related to code blocks.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines and file formatting.
 
 ---
 *This standard (SF-SYNTAX-LISTS) is based on rules 1.1 through 1.5 and the illustrative example previously defined in M-SYNTAX-LISTS-001 from COL-SYNTAX-MARKDOWN.md.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-MATH-EQUATIONS.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-MATH-EQUATIONS.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Math Equation Syntax" # As per prompt
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # For blank lines around blocks
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"] # For blank line rules around blocks
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -28,7 +28,7 @@ change_log_url: "./SF-SYNTAX-MATH-EQUATIONS-changelog.md" # Placeholder
 
 This standard defines the recommended syntax for embedding mathematical equations (both inline and as display blocks) within Markdown documents. The internal content of these equations SHOULD generally be expressed using LaTeX syntax. Consistent application of this standard facilitates the clear and accurate representation of mathematical formulas.
 
-Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block-level math equations is also important.
+Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block-level math equations is also important.
 
 ## 2. Core Math Syntax Rules (Common Extensions)
 
@@ -109,7 +109,7 @@ The content within the math delimiters (e.g., between `$`...`$`, or `$$`...`$$`)
 This standard applies to all Markdown documents within the knowledge base repository where mathematical equations are included.
 
 ## 6. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements, which applies to display math blocks.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements, which applies to display math blocks.
 
 ---
 *This standard (SF-SYNTAX-MATH-EQUATIONS) is based on common Markdown extension syntaxes for embedding LaTeX mathematical equations.*

--- a/master-knowledge-base/standards/src/SF-SYNTAX-TABLES.md
+++ b/master-knowledge-base/standards/src/SF-SYNTAX-TABLES.md
@@ -9,7 +9,7 @@ tags:
 kb-id: "" # Global standard
 info-type: "standard-definition"
 primary-topic: "Markdown Table Syntax" # As per prompt
-related-standards: ["SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER"] # For blank line rules around blocks
+related-standards: ["SF-FORMATTING-FILE-HYGIENE"] # For blank line rules around blocks
 version: "1.0.0"
 date-created: "2024-07-15T12:00:00Z"
 date-modified: "2024-07-15T12:00:00Z"
@@ -26,7 +26,7 @@ change_log_url: "./SF-SYNTAX-TABLES-changelog.md" # Placeholder
 
 ## 1. Standard Statement
 
-This standard defines the mandatory Markdown syntax for creating tables to structure and present data within all knowledge base documents. Consistent and correct table syntax is essential for readability, clear data presentation, and reliable parsing by Markdown processors. Adherence to [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] regarding blank lines around block elements is also important for tables.
+This standard defines the mandatory Markdown syntax for creating tables to structure and present data within all knowledge base documents. Consistent and correct table syntax is essential for readability, clear data presentation, and reliable parsing by Markdown processors. Adherence to [[SF-FORMATTING-FILE-HYGIENE]] regarding blank lines around block elements is also important for tables.
 
 ## 2. Core Table Syntax Rules
 
@@ -84,7 +84,7 @@ Outer pipes (`|`) at the beginning and end of each row are optional in many Mark
 *   **Rationale:** Including outer pipes makes the table structure more explicit and visually organized in the raw Markdown text, reducing ambiguity.
 
 ### Rule 2.5: Blank Lines Around Tables
-A single blank line MUST precede and a single blank line MUST follow every table block to separate it from surrounding paragraphs or other block elements, as per [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]].
+A single blank line MUST precede and a single blank line MUST follow every table block to separate it from surrounding paragraphs or other block elements, as per [[SF-FORMATTING-FILE-HYGIENE]].
 *   **Rationale:** Ensures correct table parsing and rendering.
 
 ## 3. Illustrative Example (Comprehensive)
@@ -127,7 +127,7 @@ This is a paragraph after the table.
 This standard applies to all Markdown documents within the knowledge base repository where tabular data is presented.
 
 ## 7. Cross-References
-- [[SF-FORMATTING-FILE-HYGIENE_ID_PLACEHOLDER]] - For rules on blank lines around block elements like tables.
+- [[SF-FORMATTING-FILE-HYGIENE]] - For rules on blank lines around block elements like tables.
 
 ---
 *This standard (SF-SYNTAX-TABLES) is based on common Markdown table syntax conventions.*

--- a/master-knowledge-base/standards/src/SF-TOC-SYNTAX.md
+++ b/master-knowledge-base/standards/src/SF-TOC-SYNTAX.md
@@ -83,7 +83,7 @@ Authors should verify that ToC links correctly navigate to the intended sections
 - [[CS-TOC-POLICY]] - Policy regarding ToC mandate, content depth, and generation.
 - [[AS-STRUCTURE-DOC-CHAPTER]] - Defines the placement of ToCs within chapter documents.
 - [[SF-LINKS-INTERNAL-SYNTAX]] - Governs general internal link syntax.
-- [[SF-SYNTAX-HEADINGS_ID_PLACEHOLDER]] - Governs heading syntax, which impacts anchor generation.
+- [[SF-SYNTAX-HEADINGS]] - Governs heading syntax, which impacts anchor generation.
 
 ---
 *This standard (SF-TOC-SYNTAX) formalizes the Markdown structure for Tables of Contents, supporting policies outlined in CS-TOC-POLICY and structural requirements in AS-STRUCTURE-DOC-CHAPTER. It derives from examples and implicit requirements in U-STRUC-002.*

--- a/note.md
+++ b/note.md
@@ -184,7 +184,7 @@ This file contains updates that were intended for `CONTRIBUTOR_GUIDE.md`. Due to
         -   Updated references to glossaries, templates directory, and other key architectural files to their new standard IDs.
         -   Added notes to the "Using Obsidian" section to clarify that these are now generalized standards.
 -   **Step 1.8: Refactor Guide Documents (Continued)**
-    -   **Task 1.8.2: Refactor `GUIDE-TASK-BASED.md`**
+    -   **Task 1.8.2: Refactor `GUIDE-TASK-BAED.md`**
         -   Created new guide `/master-knowledge-base/standards/src/GM-GUIDE-STANDARDS-BY-TASK.md` (standard_id: `GM-GUIDE-STANDARDS-BY-TASK`).
         -   Populated frontmatter using `tpl-canonical-frontmatter.md` as a base, with `info-type: guide-document`.
         -   Migrated content from `standards/GUIDE-TASK-BASED.md`.
@@ -193,3 +193,27 @@ This file contains updates that were intended for `CONTRIBUTOR_GUIDE.md`. Due to
 -   **Step 1.8: Refactor Guide Documents (Completed)**
     -   The original guide files `standards/GUIDE-KB-USAGE-AND-STANDARDS.md` and `standards/GUIDE-TASK-BASED.md` have been successfully refactored into `master-knowledge-base/standards/src/GM-GUIDE-KB-USAGE.md` and `master-knowledge-base/standards/src/GM-GUIDE-STANDARDS-BY-TASK.md` respectively.
     -   The original files in the `standards/` directory are now considered superseded and are candidates for deletion or archival in a later cleanup phase. No direct modifications (like adding deprecation notices) will be made to these old files at this time, as their replacements are now the authoritative versions.
+
+## Unresolved/Unmapped Placeholders Encountered During Link Updates (Phase 2.1)
+
+The following placeholder IDs were found in files within `/master-knowledge-base/standards/src/` but were not included in the provided replacement mapping. They have been left unchanged for now and require further investigation:
+
+-   `HYPOTHESIS-TESTING_ID_PLACEHOLDER` (found in `AS-SCHEMA-CONCEPT-DEFINITION.md`)
+-   `P-VALUE_ID_PLACEHOLDER` (found in `AS-SCHEMA-CONCEPT-DEFINITION.md`)
+-   `ANOTHER-RELEVANT-STANDARD_ID_PLACEHOLDER` (found in `AS-STRUCTURE-DOC-CHAPTER.md`)
+-   `CORE-CONCEPT-RESEARCH_ID_PLACEHOLDER` (found in `AS-STRUCTURE-DOC-CHAPTER.md`)
+-   `FILENAME_ID_PLACEHOLDER` (found in comments in `AS-STRUCTURE-KB-PART.md`, `AS-STRUCTURE-KB-ROOT.md`, `AS-STRUCTURE-MASTER-KB-INDEX.md` - likely not actual links)
+-   `Advanced Settings Guide_ID_PLACEHOLDER` (found in `CS-CONTENT-PROFILING-POLICY.md`)
+-   `NEW-STANDARD-ID_PLACEHOLDER` (found in `OM-POLICY-STANDARDS-DEPRECATION.md` example)
+
+### Decision ID DECISION_002: Refactor KB Standards (Continued)
+
+**Phase 2: Governance Review & Standalone Document Refactoring (In Progress)**
+
+-   **Step 2.2: Refactor Existing Standalone Standard Files**
+    -   **Processed `standards/U-KEYREF-SYNTAX-001.md`**:
+        -   Created new atomic standard `/master-knowledge-base/standards/src/SF-SYNTAX-KEYREF.md` (standard_id: `SF-SYNTAX-KEYREF`).
+        -   `info-type` set to `standard-definition`.
+        -   Frontmatter populated according to `tpl-canonical-frontmatter.md`.
+        -   Content migrated from `U-KEYREF-SYNTAX-001`, defining the `{{key.name}}` syntax, camelCase recommendation for key names, and no whitespace rule.
+        -   Cross-references updated to point to anticipated new standard IDs like `[[MT-KEYREF-MANAGEMENT]]` and `[[UA-KEYDEFS-GLOBAL]]`.


### PR DESCRIPTION
…F-SYNTAX

This commit addresses initial tasks of Phase 2 of the KB Standards Refactoring roadmap.

Key changes:
- Reviewed atomic files from Phase 1. Systematically corrected numerous `[[LEGACY_ID_PLACEHOLDER]]` style links to their proper `[[STANDARD_ID]]` format across most files in `/master-knowledge-base/standards/src/`. This improves link integrity and prepares for future validation.
- Refactored the standalone standard `standards/U-KEYREF-SYNTAX-001.md` into the new atomic standard `/master-knowledge-base/standards/src/SF-SYNTAX-KEYREF.md` (ID: SF-SYNTAX-KEYREF), including updated frontmatter and content adaptation.
- Updated `note.md` to log these actions and to list any unmapped placeholders encountered during the link cleanup for future investigation.